### PR TITLE
docs: add interface documentation

### DIFF
--- a/Pkuyo.CanKit.Net/Core/Abstractions/ICanChannel.cs
+++ b/Pkuyo.CanKit.Net/Core/Abstractions/ICanChannel.cs
@@ -5,34 +5,83 @@ using Pkuyo.CanKit.Net.Core.Definitions;
 namespace Pkuyo.CanKit.Net.Core.Abstractions
 {
 
+    /// <summary>
+    ///     表示 CAN 通道在运行时暴露的最小功能集合。
+    /// </summary>
+    /// <remarks>
+    ///     通道负责协调底层设备的打开、关闭以及报文的收发等生命周期操作。
+    /// </remarks>
     public interface ICanChannel : IDisposable
     {
+        /// <summary>
+        ///     打开当前通道并使其进入可通信的工作状态。
+        /// </summary>
         void Open();
-        
+
+        /// <summary>
+        ///     关闭当前通道并释放与之相关的临时资源。
+        /// </summary>
         void Close();
 
+        /// <summary>
+        ///     将通道恢复到初始状态，通常用于错误恢复或重新初始化。
+        /// </summary>
         void Reset();
 
+        /// <summary>
+        ///     清空通道内部缓存的数据，例如接收缓存和发送队列。
+        /// </summary>
         void CleanBuffer();
 
+        /// <summary>
+        ///     向总线上发送一个或多个 CAN 帧。
+        /// </summary>
+        /// <param name="frames">需要发送的帧集合。</param>
+        /// <returns>成功写入底层硬件缓冲区的帧数量。</returns>
         uint Transmit(params CanTransmitData[] frames);
-        
+
+        /// <summary>
+        ///     从通道中读取 CAN 帧。
+        /// </summary>
+        /// <param name="count">希望读取的最大帧数。</param>
+        /// <param name="timeOut">等待数据的超时时间，单位为毫秒，-1 表示无限等待。</param>
+        /// <returns>读取到的 CAN 帧序列。</returns>
         IEnumerable<CanReceiveData> Receive(uint count = 1, int timeOut = -1);
 
+        /// <summary>
+        ///     获取当前接收缓冲区中可读取的帧数量。
+        /// </summary>
+        /// <returns>接收缓冲区中帧的数量。</returns>
         uint GetReceiveCount();
 
+        /// <summary>
+        ///     获取用于访问运行时参数的配置器。
+        /// </summary>
         IChannelRTOptionsConfigurator Options { get; }
 
+        /// <summary>
+        ///     当收到新的 CAN 帧时触发。
+        /// </summary>
         event EventHandler<CanReceiveData> FrameReceived;
-        
+
+        /// <summary>
+        ///     当通道运行时出现错误帧时触发。
+        /// </summary>
         event EventHandler<CanErrorFrame> ErrorOccurred;
     }
-    
 
+
+    /// <summary>
+    ///     带有强类型配置器的 CAN 通道接口。
+    /// </summary>
+    /// <typeparam name="TConfigurator">通道运行时配置器的具体类型。</typeparam>
     public interface ICanChannel<out TConfigurator> : ICanChannel
         where TConfigurator : IChannelRTOptionsConfigurator
-    { 
+    {
+        /// <summary>
+        ///     获取强类型的运行时配置访问器。
+        /// </summary>
         new TConfigurator Options { get; }
     }
-    
+
 }

--- a/Pkuyo.CanKit.Net/Core/Abstractions/ICanDevice.cs
+++ b/Pkuyo.CanKit.Net/Core/Abstractions/ICanDevice.cs
@@ -3,21 +3,44 @@ using Pkuyo.CanKit.Net.Core.Definitions;
 
 namespace Pkuyo.CanKit.Net.Core.Abstractions
 {
+    /// <summary>
+    ///     表示一个 CAN 物理设备，负责与硬件适配器交互。
+    /// </summary>
     public interface ICanDevice : IDisposable
     {
 
+        /// <summary>
+        ///     打开设备资源并做好进行通道操作的准备。
+        /// </summary>
+        /// <returns>打开设备是否成功。</returns>
         bool OpenDevice();
 
+        /// <summary>
+        ///     关闭设备连接并释放相关资源。
+        /// </summary>
         void CloseDevice();
 
+        /// <summary>
+        ///     获取设备当前是否已处于打开状态。
+        /// </summary>
         bool IsDeviceOpen { get; }
-        
+
+        /// <summary>
+        ///     获取用于访问运行时设备参数的配置器。
+        /// </summary>
         IDeviceRTOptionsConfigurator Options { get; }
     }
 
+    /// <summary>
+    ///     强类型化运行时配置访问器的设备接口。
+    /// </summary>
+    /// <typeparam name="TConfigurator">设备运行时配置器的具体类型。</typeparam>
     public interface ICanDevice<out TConfigurator> : ICanDevice
         where TConfigurator : IDeviceRTOptionsConfigurator
     {
+        /// <summary>
+        ///     获取强类型的运行时配置访问器。
+        /// </summary>
         new TConfigurator Options { get; }
     }
 }

--- a/Pkuyo.CanKit.Net/Core/Abstractions/ICanFactory.cs
+++ b/Pkuyo.CanKit.Net/Core/Abstractions/ICanFactory.cs
@@ -3,14 +3,40 @@ using Pkuyo.CanKit.Net.Core.Definitions;
 
 namespace Pkuyo.CanKit.Net.Core.Abstractions;
 
+/// <summary>
+///     定义用于构建 CAN 相关实例的工厂接口。
+/// </summary>
 public interface ICanFactory
-{
+{ 
+    /// <summary>
+    ///     根据提供的配置创建一个设备实例。
+    /// </summary>
+    /// <param name="options">用于初始化设备的配置。</param>
+    /// <returns>创建完成的 <see cref="ICanDevice"/>。</returns>
     ICanDevice CreateDevice(IDeviceOptions options);
-    
+
+    /// <summary>
+    ///     基于指定的设备和配置创建一个通道实例。
+    /// </summary>
+    /// <param name="device">通道依附的设备实例。</param>
+    /// <param name="options">通道初始化所需的配置。</param>
+    /// <param name="transceiver">与通道配套使用的收发器。</param>
+    /// <returns>创建完成的 <see cref="ICanChannel"/>。</returns>
     ICanChannel CreateChannel(ICanDevice device, IChannelOptions options, ITransceiver transceiver);
-    
+
+    /// <summary>
+    ///     创建一个与指定配置匹配的收发器实例。
+    /// </summary>
+    /// <param name="deviceOptions">设备运行时配置访问器。</param>
+    /// <param name="channelOptions">通道初始化配置访问器。</param>
+    /// <returns>构建完成的 <see cref="ITransceiver"/>。</returns>
     ITransceiver CreateTransceivers(IDeviceRTOptionsConfigurator deviceOptions,
         IChannelInitOptionsConfigurator channelOptions);
-    
+
+    /// <summary>
+    ///     判断当前工厂是否支持指定类型的设备。
+    /// </summary>
+    /// <param name="deviceType">待检测的设备类型。</param>
+    /// <returns>若支持该设备类型则返回 <c>true</c>，否则返回 <c>false</c>。</returns>
     bool Support(DeviceType deviceType);
 }

--- a/Pkuyo.CanKit.Net/Core/Abstractions/ICanModelProvider.cs
+++ b/Pkuyo.CanKit.Net/Core/Abstractions/ICanModelProvider.cs
@@ -4,17 +4,38 @@ using Pkuyo.CanKit.Net.Core.Definitions;
 namespace Pkuyo.CanKit.Net.Core.Abstractions
 {
     
+    /// <summary>
+    ///     定义提供特定设备型号及其配置能力的提供程序接口。
+    /// </summary>
     public interface ICanModelProvider
     {
+        /// <summary>
+        ///     获取当前模型对应的设备类型。
+        /// </summary>
         DeviceType DeviceType { get; }
-        
+
+        /// <summary>
+        ///     获取模型支持的功能集合。
+        /// </summary>
         CanFeature Features { get; }
 
+        /// <summary>
+        ///     获取用于创建设备、通道以及收发器的工厂实例。
+        /// </summary>
         ICanFactory Factory { get; }
-        
+
+        /// <summary>
+        ///     创建默认的设备配置对象及其初始化配置器。
+        /// </summary>
+        /// <returns>包含设备配置以及初始化配置器的二元组。</returns>
         (IDeviceOptions,IDeviceInitOptionsConfigurator) GetDeviceOptions();
-        
+
+        /// <summary>
+        ///     为指定索引的通道创建配置对象与初始化配置器。
+        /// </summary>
+        /// <param name="channelIndex">目标通道的索引。</param>
+        /// <returns>包含通道配置以及初始化配置器的二元组。</returns>
         (IChannelOptions,IChannelInitOptionsConfigurator) GetChannelOptions(int channelIndex);
-        
+
     }
 }

--- a/Pkuyo.CanKit.Net/Core/Abstractions/ICanOptions.cs
+++ b/Pkuyo.CanKit.Net/Core/Abstractions/ICanOptions.cs
@@ -4,51 +4,117 @@ using Pkuyo.CanKit.Net.Core.Definitions;
 namespace Pkuyo.CanKit.Net.Core.Abstractions
 {
     
-
+    /// <summary>
+    ///     定义将配置项应用到目标对象的行为。
+    /// </summary>
     public interface ICanApplier
     {
+        /// <summary>
+        ///     尝试将单个配置项应用到目标对象。
+        /// </summary>
+        /// <typeparam name="T">配置值的类型。</typeparam>
+        /// <param name="name">配置项名称。</param>
+        /// <param name="value">配置项的目标值。</param>
+        /// <returns>应用是否成功。</returns>
         bool ApplyOne<T>(string name, T value);
 
+        /// <summary>
+        ///     批量应用另一份配置对象中的内容。
+        /// </summary>
+        /// <param name="options">需要被应用的配置对象。</param>
         void Apply(ICanOptions options);
-        
+
+        /// <summary>
+        ///     获取当前应用器的状态，用于指示配置项是否完全生效。
+        /// </summary>
         CanOptionType ApplierStatus { get; }
     }
-    
+
+    /// <summary>
+    ///     表示具有统一应用能力的配置对象。
+    /// </summary>
     public interface ICanOptions
     {
+        /// <summary>
+        ///     获取创建当前配置的模型提供程序。
+        /// </summary>
         ICanModelProvider Provider { get; }
-        
+
+        /// <summary>
+        ///     使用给定的应用器对配置执行应用操作。
+        /// </summary>
+        /// <param name="applier">用于解释并写入配置项的应用器。</param>
+        /// <param name="force">是否强制应用，即使目标应用器状态不完全匹配。</param>
         void Apply(ICanApplier applier, bool force = false);
     }
 
 
 
+    /// <summary>
+    ///     定义与 CAN 设备相关的配置。
+    /// </summary>
     public interface IDeviceOptions : ICanOptions
     {
+        /// <summary>
+        ///     获取设备的类型。
+        /// </summary>
         DeviceType DeviceType { get; }
 
+        /// <summary>
+        ///     获取或设置发送超时时间，单位为毫秒。
+        /// </summary>
         uint TxTimeOut { get; set; }
     }
 
+    /// <summary>
+    ///     定义与 CAN 通道相关的配置。
+    /// </summary>
     public interface IChannelOptions : ICanOptions
     {
-        
+
+        /// <summary>
+        ///     获取或设置通道索引。
+        /// </summary>
         int ChannelIndex { get; set; }
-        
+
+        /// <summary>
+        ///     获取或设置通道使用的位时序参数。
+        /// </summary>
         BitTiming BitTiming { get; set; }
-        
+
+        /// <summary>
+        ///     获取或设置是否启用内部终端电阻。
+        /// </summary>
         bool InternalResistance { get; set; }
-        
+
+        /// <summary>
+        ///     获取或设置是否启用总线负载监控。
+        /// </summary>
         bool BusUsageEnabled { get; set; }
-        
+
+        /// <summary>
+        ///     获取或设置总线负载监控的周期，单位为毫秒。
+        /// </summary>
         uint BusUsagePeriodTime { get; set; }
-        
+
+        /// <summary>
+        ///     获取或设置通道的工作模式。
+        /// </summary>
         ChannelWorkMode WorkMode { get; set; }
-        
+
+        /// <summary>
+        ///     获取或设置发送重试策略。
+        /// </summary>
         TxRetryPolicy TxRetryPolicy { get; set; }
-        
+
+        /// <summary>
+        ///     获取或设置 CAN 协议模式（例如标准、FD 等）。
+        /// </summary>
         CanProtocolMode ProtocolMode { get; set; }
-        
+
+        /// <summary>
+        ///     获取或设置接收过滤器参数。
+        /// </summary>
         CanFilter Filter { get; set; }
     }
 }

--- a/Pkuyo.CanKit.Net/Core/Abstractions/IOptionsConfigurator.cs
+++ b/Pkuyo.CanKit.Net/Core/Abstractions/IOptionsConfigurator.cs
@@ -1,90 +1,235 @@
-using Pkuyo.CanKit.Net.Core.Definitions;
+﻿using Pkuyo.CanKit.Net.Core.Definitions;
 
 namespace Pkuyo.CanKit.Net.Core.Abstractions;
 
 
+/// <summary>
+///     提供访问通用配置上下文的基础接口。
+/// </summary>
 public interface ICanOptionsConfigurator
-{
+{ 
+    /// <summary>
+    ///     获取创建当前配置器的模型提供程序。
+    /// </summary>
     ICanModelProvider Provider { get; }
 }
 
+/// <summary>
+///     定义在运行时获取设备相关参数的配置器。
+/// </summary>
 public interface IDeviceRTOptionsConfigurator : ICanOptionsConfigurator
-{
-   
+{ 
+
+    /// <summary>
+    ///     获取设备的类型。
+    /// </summary>
     DeviceType DeviceType { get; }
-  
+
+    /// <summary>
+    ///     获取发送超时时间，单位为毫秒。
+    /// </summary>
     uint TxTimeOut { get; }
 }
 
 
+/// <summary>
+///     定义在运行时读取通道参数的配置器。
+/// </summary>
 public interface IChannelRTOptionsConfigurator : ICanOptionsConfigurator
-{
+{ 
+    /// <summary>
+    ///     获取通道索引。
+    /// </summary>
     int ChannelIndex { get; }
-    
+
+    /// <summary>
+    ///     获取通道的位时序设置。
+    /// </summary>
     BitTiming BitTiming { get; }
-    
+
+    /// <summary>
+    ///     获取发送重试策略。
+    /// </summary>
     TxRetryPolicy TxRetryPolicy { get; }
-    
+
+    /// <summary>
+    ///     获取是否启用总线负载监控。
+    /// </summary>
     bool BusUsageEnabled { get; }
-    
+
+    /// <summary>
+    ///     获取总线负载监控的周期，单位为毫秒。
+    /// </summary>
     uint BusUsagePeriodTime { get; }
-    
+
+    /// <summary>
+    ///     获取通道的工作模式。
+    /// </summary>
     ChannelWorkMode WorkMode { get; }
-    
-    bool InternalResistance { get; } 
-    
+
+    /// <summary>
+    ///     获取是否启用了内部终端电阻。
+    /// </summary>
+    bool InternalResistance { get; }
+
+    /// <summary>
+    ///     获取 CAN 协议模式。
+    /// </summary>
     CanProtocolMode ProtocolMode { get; }
-    
+
+    /// <summary>
+    ///     获取当前使用的过滤器对象。
+    /// </summary>
     ICanFilter Filter { get; }
 }
 
+/// <summary>
+///     定义用于构建设备初始化配置的配置器。
+/// </summary>
 public interface IDeviceInitOptionsConfigurator : ICanOptionsConfigurator
-{
+{ 
+    /// <summary>
+    ///     获取设备类型。
+    /// </summary>
     DeviceType DeviceType { get; }
+
+    /// <summary>
+    ///     获取发送超时的默认值，单位为毫秒。
+    /// </summary>
     uint TxTimeOutTime { get; }
-    
+
+    /// <summary>
+    ///     设置发送超时并返回自身以便链式调用。
+    /// </summary>
+    /// <param name="ms">超时时间，单位为毫秒。</param>
+    /// <returns>当前配置器实例。</returns>
     IDeviceInitOptionsConfigurator TxTimeOut(uint ms);
 }
 
+/// <summary>
+///     定义用于构建通道初始化配置的配置器。
+/// </summary>
 public interface IChannelInitOptionsConfigurator : ICanOptionsConfigurator
-{
-    
+{ 
+
+    /// <summary>
+    ///     获取通道索引。
+    /// </summary>
     int ChannelIndex { get; }
-    
+
+    /// <summary>
+    ///     获取位时序设置。
+    /// </summary>
     BitTiming BitTiming { get; }
-    
+
+    /// <summary>
+    ///     获取发送重试策略。
+    /// </summary>
     TxRetryPolicy TxRetryPolicy { get; }
-    
+
+    /// <summary>
+    ///     获取是否启用总线负载监控。
+    /// </summary>
     bool BusUsageEnabled { get; }
-    
+
+    /// <summary>
+    ///     获取总线负载监控周期，单位为毫秒。
+    /// </summary>
     uint BusUsagePeriodTime { get; }
-    
+
+    /// <summary>
+    ///     获取工作模式。
+    /// </summary>
     ChannelWorkMode WorkMode { get; }
-    
+
+    /// <summary>
+    ///     获取是否启用内部终端电阻。
+    /// </summary>
     bool InternalResistance { get; }
-    
+
+    /// <summary>
+    ///     获取协议模式。
+    /// </summary>
     CanProtocolMode ProtocolMode { get; }
-    
+
+    /// <summary>
+    ///     获取过滤器对象。
+    /// </summary>
     ICanFilter Filter { get; }
-    
+
+    /// <summary>
+    ///     设置通道波特率。
+    /// </summary>
+    /// <param name="baud">目标波特率。</param>
+    /// <returns>当前配置器实例。</returns>
     IChannelInitOptionsConfigurator Baud(uint baud);
-    
+
+    /// <summary>
+    ///     设置 CAN FD 模式的仲裁段与数据段波特率。
+    /// </summary>
+    /// <param name="abit">仲裁段波特率。</param>
+    /// <param name="dbit">数据段波特率。</param>
+    /// <returns>当前配置器实例。</returns>
     IChannelInitOptionsConfigurator Fd(uint abit, uint dbit);
-    
+
+    /// <summary>
+    ///     启用总线占用监控并设置周期。
+    /// </summary>
+    /// <param name="periodMs">监控周期，单位为毫秒。</param>
+    /// <returns>当前配置器实例。</returns>
     IChannelInitOptionsConfigurator BusUsage(uint periodMs = 1000);
-    
+
+    /// <summary>
+    ///     配置是否启用内部终端电阻。
+    /// </summary>
+    /// <param name="enabled">若为 <c>true</c> 则启用内部终端电阻。</param>
+    /// <returns>当前配置器实例。</returns>
     IChannelInitOptionsConfigurator InternalRes(bool enabled);
-    
+
+    /// <summary>
+    ///     设置发送重试策略。
+    /// </summary>
+    /// <param name="retryPolicy">重试策略。</param>
+    /// <returns>当前配置器实例。</returns>
     IChannelInitOptionsConfigurator SetTxRetryPolicy(TxRetryPolicy retryPolicy);
-    
+
+    /// <summary>
+    ///     设置通道工作模式。
+    /// </summary>
+    /// <param name="mode">目标工作模式。</param>
+    /// <returns>当前配置器实例。</returns>
     IChannelInitOptionsConfigurator SetWorkMode(ChannelWorkMode mode);
-    
+
+    /// <summary>
+    ///     设置协议模式。
+    /// </summary>
+    /// <param name="mode">目标协议模式。</param>
+    /// <returns>当前配置器实例。</returns>
     IChannelInitOptionsConfigurator SetProtocolMode(CanProtocolMode mode);
-    
+
+    /// <summary>
+    ///     设置过滤器。
+    /// </summary>
+    /// <param name="filter">过滤器参数。</param>
+    /// <returns>当前配置器实例。</returns>
     IChannelInitOptionsConfigurator SetFilter(CanFilter filter);
-    
+
+    /// <summary>
+    ///     按照 ID 范围配置过滤器。
+    /// </summary>
+    /// <param name="min">最小 ID。</param>
+    /// <param name="max">最大 ID。</param>
+    /// <param name="idType">过滤器的 ID 类型。</param>
+    /// <returns>当前配置器实例。</returns>
     IChannelInitOptionsConfigurator RangeFilter(uint min, uint max, FilterIDType idType);
-    
+
+    /// <summary>
+    ///     通过验收码与掩码配置过滤器。
+    /// </summary>
+    /// <param name="accCode">验收码。</param>
+    /// <param name="accMask">验收掩码。</param>
+    /// <param name="idType">过滤器的 ID 类型。</param>
+    /// <returns>当前配置器实例。</returns>
     IChannelInitOptionsConfigurator AccMask(uint accCode, uint accMask, FilterIDType idType);
 }
 

--- a/Pkuyo.CanKit.Net/Core/Abstractions/ITransceiver.cs
+++ b/Pkuyo.CanKit.Net/Core/Abstractions/ITransceiver.cs
@@ -1,14 +1,32 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading;
 using Pkuyo.CanKit.Net.Core.Definitions;
 
 namespace Pkuyo.CanKit.Net.Core.Abstractions
 {
+    /// <summary>
+    ///     定义 CAN 收发器在逻辑层面提供的能力。
+    /// </summary>
     public interface ITransceiver
     {
-        uint Transmit(ICanChannel<IChannelRTOptionsConfigurator> channel ,params CanTransmitData[] frames);
-        
-        IEnumerable<CanReceiveData> Receive(ICanChannel<IChannelRTOptionsConfigurator> channel, uint count = 1, int timeOut = -1);
-        
+        /// <summary>
+        ///     通过指定通道发送一个或多个 CAN 帧。
+        /// </summary>
+        /// <param name="channel">执行发送操作的通道。</param>
+        /// <param name="frames">需要发送的帧集合。</param>
+        /// <returns>成功写入硬件的帧数量。</returns>
+        uint Transmit(ICanChannel<IChannelRTOptionsConfigurator> channel, params CanTransmitData[] frames);
+
+        /// <summary>
+        ///     通过指定通道接收 CAN 帧。
+        /// </summary>
+        /// <param name="channel">执行接收操作的通道。</param>
+        /// <param name="count">期望接收的最大帧数量。</param>
+        /// <param name="timeOut">等待数据的超时时间，单位为毫秒，-1 表示无限等待。</param>
+        /// <returns>接收到的帧集合。</returns>
+        IEnumerable<CanReceiveData> Receive(
+            ICanChannel<IChannelRTOptionsConfigurator> channel,
+            uint count = 1,
+            int timeOut = -1);
     }
 }


### PR DESCRIPTION
## Summary
- add XML documentation comments for the core CAN channel and device interfaces to explain lifecycle and event behavior
- describe factory, model provider, and options interfaces to clarify responsibilities and configuration flows
- document transceiver APIs and the various runtime/init options configurators for fluent configuration guidance

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca0d2767308322b33756a0d2151a4f