### PR TITLE
Implement CAN exception handling and logging

### DIFF
--- a/Pkuyo.CanKit.Net.ZLG/Diagnostics/ZlgErr.cs
+++ b/Pkuyo.CanKit.Net.ZLG/Diagnostics/ZlgErr.cs
@@ -1,14 +1,50 @@
-﻿using System;
+using System;
+using Pkuyo.CanKit.Net.Core.Diagnostics;
+using Pkuyo.CanKit.ZLG.Exceptions;
+using Pkuyo.CanKit.ZLG.Native;
 
-namespace Pkuyo.CanKit.Net.Core.Diagnostics
+namespace Pkuyo.CanKit.ZLG.Diagnostics
 {
     public static class ZlgErr
     {
+        public const uint StatusOk = 1;
 
-        public static void ThrowIfError(uint err)
+        public static void ThrowIfError(uint status, string operation, ZlgChannelHandle? channelHandle = null, string? message = null)
         {
-            if (err != 1)
-                throw new Exception();
+            if (status == StatusOk)
+            {
+                return;
+            }
+
+            ZLGCAN.ZCAN_CHANNEL_ERROR_INFO? errorInfo = null;
+
+            if (channelHandle is { IsInvalid: false } handle)
+            {
+                try
+                {
+                    var nativeInfo = new ZLGCAN.ZCAN_CHANNEL_ERROR_INFO();
+                    ZLGCAN.ZCAN_ReadChannelErrInfo(handle, ref nativeInfo);
+                    errorInfo = nativeInfo;
+                }
+                catch (Exception ex)
+                {
+                    CanKitLogger.LogWarning($"Failed to query channel error information for operation '{operation}'.", ex);
+                }
+            }
+
+            message ??= $"ZLG native call '{operation}' failed with status {status}.";
+            throw new ZlgCanException(operation, message, status, errorInfo);
+        }
+
+        public static void ThrowIfInvalid(ZlgChannelHandle handle, string operation)
+        {
+            if (handle == null) throw new ArgumentNullException(nameof(handle));
+            if (!handle.IsInvalid)
+            {
+                return;
+            }
+
+            throw new ZlgCanException(operation, $"ZLG native call '{operation}' returned an invalid handle.", 0);
         }
     }
 }

--- a/Pkuyo.CanKit.Net.ZLG/Exceptions/ZlgCanException.cs
+++ b/Pkuyo.CanKit.Net.ZLG/Exceptions/ZlgCanException.cs
@@ -1,0 +1,20 @@
+using Pkuyo.CanKit.Net.Core.Exceptions;
+using Pkuyo.CanKit.ZLG.Native;
+
+namespace Pkuyo.CanKit.ZLG.Exceptions
+{
+    public class ZlgCanException : CanNativeCallException
+    {
+        public ZlgCanException(string operation, string message, uint statusCode,
+            ZLGCAN.ZCAN_CHANNEL_ERROR_INFO? channelErrorInfo = null)
+            : base(operation, message, statusCode)
+        {
+            StatusCode = statusCode;
+            ChannelErrorInfo = channelErrorInfo;
+        }
+
+        public uint StatusCode { get; }
+
+        public ZLGCAN.ZCAN_CHANNEL_ERROR_INFO? ChannelErrorInfo { get; }
+    }
+}

--- a/Pkuyo.CanKit.Net.ZLG/ZlgCanDevice.cs
+++ b/Pkuyo.CanKit.Net.ZLG/ZlgCanDevice.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using Pkuyo.CanKit.Net.Core.Abstractions;
 using Pkuyo.CanKit.Net.Core.Definitions;
+using Pkuyo.CanKit.Net.Core.Diagnostics;
+using Pkuyo.CanKit.Net.Core.Exceptions;
 using Pkuyo.CanKit.ZLG.Definitions;
 using Pkuyo.CanKit.ZLG.Native;
 using Pkuyo.CanKit.ZLG.Options;
@@ -29,6 +31,7 @@ namespace Pkuyo.CanKit.ZLG
                 return IsDeviceOpen;
             }
 
+            CanKitLogger.LogWarning($"Failed to open ZLG device '{Options.DeviceType.Id}' at index {Options.DeviceIndex}.");
             return false;
         }
 
@@ -43,7 +46,7 @@ namespace Pkuyo.CanKit.ZLG
         private void ThrowIfDisposed()
         {
             if (_isDisposed)
-                throw new InvalidOperationException();
+                throw new CanDeviceDisposedException();
         }
         
         

--- a/Pkuyo.CanKit.Net/Can.cs
+++ b/Pkuyo.CanKit.Net/Can.cs
@@ -1,51 +1,72 @@
-﻿using System;
-using System.Collections.Generic;
+using System;
 using Pkuyo.CanKit.Net.Core;
 using Pkuyo.CanKit.Net.Core.Abstractions;
 using Pkuyo.CanKit.Net.Core.Definitions;
+using Pkuyo.CanKit.Net.Core.Exceptions;
 using Pkuyo.CanKit.Net.Core.Registry;
 
 namespace Pkuyo.CanKit.Net
 {
     public static class Can
     {
-        public static CanSession<ICanDevice,ICanChannel> Open(DeviceType deviceType, Action<IDeviceInitOptionsConfigurator> configure = null)
+        public static CanSession<ICanDevice, ICanChannel> Open(DeviceType deviceType, Action<IDeviceInitOptionsConfigurator> configure = null)
         {
-            return Open<ICanDevice,ICanChannel,IDeviceOptions,IDeviceInitOptionsConfigurator>(deviceType, configure);
+            return Open<ICanDevice, ICanChannel, IDeviceOptions, IDeviceInitOptionsConfigurator>(deviceType, configure);
         }
-        
-        public static CanSession<TDevice,TChannel> Open<TDevice,TChannel,TDeviceOptions,TOptionCfg>
-        (DeviceType deviceType,
+
+        public static CanSession<TDevice, TChannel> Open<TDevice, TChannel, TDeviceOptions, TOptionCfg>(
+            DeviceType deviceType,
             Action<TOptionCfg> configure = null,
-            Func<TDevice,ICanModelProvider,CanSession<TDevice,TChannel>> sessionBuilder = null)
-            where TDevice :  class, ICanDevice
+            Func<TDevice, ICanModelProvider, CanSession<TDevice, TChannel>> sessionBuilder = null)
+            where TDevice : class, ICanDevice
             where TChannel : class, ICanChannel
-            where TDeviceOptions : class, IDeviceOptions 
+            where TDeviceOptions : class, IDeviceOptions
             where TOptionCfg : IDeviceInitOptionsConfigurator
         {
             var provider = CanRegistry.Registry.Resolve(deviceType);
             var factory = provider.Factory;
 
             var (options, cfg) = provider.GetDeviceOptions();
-            if (options is not TDeviceOptions ||
-                cfg is not TOptionCfg specCfg)
-                throw new Exception(); //TODO: 异常处理
-            
-            if (configure != null)
+
+            if (options is not TDeviceOptions typedOptions)
             {
-                configure(specCfg);
+                throw new CanOptionTypeMismatchException(
+                    CanKitErrorCode.DeviceOptionTypeMismatch,
+                    typeof(TDeviceOptions),
+                    options?.GetType() ?? typeof(IDeviceOptions),
+                    "device");
             }
-            
-            if(factory.CreateDevice(options) is not TDevice device)
-                throw new Exception(); //TODO: 异常处理
+
+            if (cfg is not TOptionCfg specCfg)
+            {
+                throw new CanOptionTypeMismatchException(
+                    CanKitErrorCode.DeviceOptionTypeMismatch,
+                    typeof(TOptionCfg),
+                    cfg?.GetType() ?? typeof(IDeviceInitOptionsConfigurator),
+                    "device configurator");
+            }
+
+            configure?.Invoke(specCfg);
+
+            var createdDevice = factory.CreateDevice(typedOptions);
+            if (createdDevice == null)
+            {
+                throw new CanFactoryException(
+                    CanKitErrorCode.DeviceCreationFailed,
+                    $"Factory '{factory.GetType().FullName}' failed to create a CAN device for '{deviceType.Id}'.");
+            }
+
+            if (createdDevice is not TDevice device)
+            {
+                throw new CanFactoryDeviceMismatchException(typeof(TDevice), createdDevice.GetType());
+            }
 
             var session = sessionBuilder == null
-                ? new CanSession<TDevice,TChannel>(device, provider)
+                ? new CanSession<TDevice, TChannel>(device, provider)
                 : sessionBuilder(device, provider);
-            
+
             session.Open();
             return session;
         }
-
     }
 }

--- a/Pkuyo.CanKit.Net/Core/Definitions/OptionsConfigurator.cs
+++ b/Pkuyo.CanKit.Net/Core/Definitions/OptionsConfigurator.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Linq;
 using Pkuyo.CanKit.Net.Core.Abstractions;
+using Pkuyo.CanKit.Net.Core.Exceptions;
 using Pkuyo.CanKit.Net.Core.Utils;
 
 namespace Pkuyo.CanKit.Net.Core.Definitions
@@ -148,8 +149,8 @@ namespace Pkuyo.CanKit.Net.Core.Definitions
             _options.Filter ??= new CanFilter();
             
             if(_options.Filter.filterRules.Count > 0 && _options.Filter.filterRules
-                   .All(x => x is FilterRule.Range))
-                throw new Exception("Filter types are different");
+                   .Any(x => x is not FilterRule.Range))
+                throw new CanFilterConfigurationException("Mixed filter rule types are not supported for range filters.");
             
             _options.Filter.filterRules.Add(new FilterRule.Range(min, max, idType));
             return (TSelf)this;
@@ -162,8 +163,8 @@ namespace Pkuyo.CanKit.Net.Core.Definitions
             
             _options.Filter ??= new CanFilter();
             if(_options.Filter.filterRules.Count > 0 && _options.Filter.filterRules
-                   .All(x => x is FilterRule.Mask))
-                throw new Exception("Filter types are different");
+                   .Any(x => x is not FilterRule.Mask))
+                throw new CanFilterConfigurationException("Mixed filter rule types are not supported for mask filters.");
             
             _options.Filter.filterRules.Add(new FilterRule.Mask(accCode, accMask, idType));
             return (TSelf)this;

--- a/Pkuyo.CanKit.Net/Core/Diagnostics/CanKitLogger.cs
+++ b/Pkuyo.CanKit.Net/Core/Diagnostics/CanKitLogger.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Diagnostics;
+
+namespace Pkuyo.CanKit.Net.Core.Diagnostics
+{
+    public enum CanKitLogLevel
+    {
+        Debug,
+        Information,
+        Warning,
+        Error
+    }
+
+    public readonly record struct CanKitLogEntry(
+        DateTime Timestamp,
+        CanKitLogLevel Level,
+        string Message,
+        Exception? Exception)
+    {
+        public override string ToString()
+        {
+            if (Exception == null)
+            {
+                return $"[{Timestamp:O}] [{Level}] {Message}";
+            }
+
+            return $"[{Timestamp:O}] [{Level}] {Message} :: {Exception}";
+        }
+    }
+
+    public static class CanKitLogger
+    {
+        private static Action<CanKitLogEntry>? _logHandler = DefaultLogHandler;
+
+        public static void Configure(Action<CanKitLogEntry> handler)
+        {
+            _logHandler = handler ?? throw new ArgumentNullException(nameof(handler));
+        }
+
+        public static void Log(CanKitLogLevel level, string message, Exception? exception = null)
+        {
+            if (message == null) throw new ArgumentNullException(nameof(message));
+
+            var entry = new CanKitLogEntry(DateTime.UtcNow, level, message, exception);
+            var handler = _logHandler;
+            handler?.Invoke(entry);
+        }
+
+        public static void LogException(Exception exception, string? message = null)
+        {
+            if (exception == null) throw new ArgumentNullException(nameof(exception));
+            Log(CanKitLogLevel.Error, message ?? exception.Message, exception);
+        }
+
+        public static void LogWarning(string message, Exception? exception = null)
+        {
+            Log(CanKitLogLevel.Warning, message, exception);
+        }
+
+        public static void LogInformation(string message)
+        {
+            Log(CanKitLogLevel.Information, message, null);
+        }
+
+        public static void LogDebug(string message)
+        {
+            Log(CanKitLogLevel.Debug, message, null);
+        }
+
+        private static void DefaultLogHandler(CanKitLogEntry entry)
+        {
+#if DEBUG
+            Debug.WriteLine(entry.ToString());
+#endif
+        }
+    }
+}

--- a/Pkuyo.CanKit.Net/Core/Exceptions/CanKitExceptions.cs
+++ b/Pkuyo.CanKit.Net/Core/Exceptions/CanKitExceptions.cs
@@ -1,0 +1,278 @@
+using System;
+using Pkuyo.CanKit.Net.Core.Definitions;
+using Pkuyo.CanKit.Net.Core.Diagnostics;
+
+namespace Pkuyo.CanKit.Net.Core.Exceptions
+{
+    public enum CanKitErrorCode
+    {
+        Unknown = 0,
+
+        DeviceOptionTypeMismatch = 1001,
+        DeviceCreationFailed = 1002,
+        DeviceDisposed = 1003,
+        DeviceNotOpen = 1004,
+
+        ChannelOptionTypeMismatch = 2001,
+        ChannelCreationFailed = 2002,
+        ChannelInitializationFailed = 2003,
+        ChannelStartFailed = 2004,
+        ChannelResetFailed = 2005,
+        ChannelCleanBufferFailed = 2006,
+        ChannelPollingFailed = 2007,
+        ChannelDisposed = 2008,
+        ChannelConfigurationInvalid = 2009,
+
+        TransceiverMismatch = 3001,
+        ProviderMismatch = 3002,
+        FactoryDeviceMismatch = 3003,
+
+        FilterConfigurationConflict = 4001,
+
+        FeatureNotSupported = 5001,
+
+        NativeCallFailed = 9000
+    }
+
+    public class CanKitException : Exception
+    {
+        public CanKitException(string message)
+            : this(CanKitErrorCode.Unknown, message, null, null)
+        {
+        }
+
+        public CanKitException(CanKitErrorCode errorCode, string message, uint? nativeErrorCode = null, Exception? innerException = null)
+            : base(message, innerException)
+        {
+            ErrorCode = errorCode;
+            NativeErrorCode = nativeErrorCode;
+            CanKitLogger.LogException(this);
+        }
+
+        public CanKitErrorCode ErrorCode { get; }
+
+        public uint? NativeErrorCode { get; }
+
+        public override string ToString()
+        {
+            var baseString = base.ToString();
+            var codePart = $"[{ErrorCode}] {baseString}";
+
+            if (NativeErrorCode.HasValue)
+            {
+                codePart += $" (NativeErrorCode: {NativeErrorCode.Value})";
+            }
+
+            return codePart;
+        }
+    }
+
+    public class CanConfigurationException : CanKitException
+    {
+        public CanConfigurationException(CanKitErrorCode errorCode, string message)
+            : base(errorCode, message)
+        {
+        }
+    }
+
+    public class CanOptionTypeMismatchException : CanConfigurationException
+    {
+        public CanOptionTypeMismatchException(CanKitErrorCode errorCode, Type expectedType, Type actualType, string scope)
+            : base(errorCode,
+                $"Expected {scope} options of type '{expectedType.FullName}', but got '{actualType.FullName}'.")
+        {
+            ExpectedType = expectedType;
+            ActualType = actualType;
+            Scope = scope;
+        }
+
+        public Type ExpectedType { get; }
+
+        public Type ActualType { get; }
+
+        public string Scope { get; }
+    }
+
+    public class CanFilterConfigurationException : CanConfigurationException
+    {
+        public CanFilterConfigurationException(string message)
+            : base(CanKitErrorCode.FilterConfigurationConflict, message)
+        {
+        }
+    }
+
+    public class CanChannelConfigurationException : CanConfigurationException
+    {
+        public CanChannelConfigurationException(string message)
+            : base(CanKitErrorCode.ChannelConfigurationInvalid, message)
+        {
+        }
+    }
+
+    public class CanDeviceException : CanKitException
+    {
+        public CanDeviceException(CanKitErrorCode errorCode, string message, Exception? innerException = null)
+            : base(errorCode, message, null, innerException)
+        {
+        }
+    }
+
+    public class CanDeviceDisposedException : CanDeviceException
+    {
+        public CanDeviceDisposedException()
+            : base(CanKitErrorCode.DeviceDisposed, "The CAN device has been disposed and cannot be used anymore.")
+        {
+        }
+    }
+
+    public class CanDeviceNotOpenException : CanDeviceException
+    {
+        public CanDeviceNotOpenException()
+            : base(CanKitErrorCode.DeviceNotOpen, "The CAN device must be opened before this operation can be performed.")
+        {
+        }
+    }
+
+    public class CanFactoryException : CanKitException
+    {
+        public CanFactoryException(CanKitErrorCode errorCode, string message)
+            : base(errorCode, message)
+        {
+        }
+    }
+
+    public class CanChannelException : CanKitException
+    {
+        public CanChannelException(CanKitErrorCode errorCode, string message, uint? nativeErrorCode = null, Exception? innerException = null)
+            : base(errorCode, message, nativeErrorCode, innerException)
+        {
+        }
+    }
+
+    public class CanChannelCreationException : CanChannelException
+    {
+        public CanChannelCreationException(string message)
+            : base(CanKitErrorCode.ChannelCreationFailed, message)
+        {
+        }
+    }
+
+    public class CanChannelDisposedException : CanChannelException
+    {
+        public CanChannelDisposedException()
+            : base(CanKitErrorCode.ChannelDisposed, "The CAN channel has been disposed and cannot be used anymore.")
+        {
+        }
+    }
+
+    public class CanChannelInitializationException : CanChannelException
+    {
+        public CanChannelInitializationException(string message, uint? nativeErrorCode = null)
+            : base(CanKitErrorCode.ChannelInitializationFailed, message, nativeErrorCode)
+        {
+        }
+    }
+
+    public class CanChannelStartException : CanChannelException
+    {
+        public CanChannelStartException(string message, uint? nativeErrorCode = null)
+            : base(CanKitErrorCode.ChannelStartFailed, message, nativeErrorCode)
+        {
+        }
+    }
+
+    public class CanChannelResetException : CanChannelException
+    {
+        public CanChannelResetException(string message, uint? nativeErrorCode = null)
+            : base(CanKitErrorCode.ChannelResetFailed, message, nativeErrorCode)
+        {
+        }
+    }
+
+    public class CanChannelCleanBufferException : CanChannelException
+    {
+        public CanChannelCleanBufferException(string message, uint? nativeErrorCode = null)
+            : base(CanKitErrorCode.ChannelCleanBufferFailed, message, nativeErrorCode)
+        {
+        }
+    }
+
+    public class CanChannelPollingException : CanChannelException
+    {
+        public CanChannelPollingException(string message, Exception? innerException = null)
+            : base(CanKitErrorCode.ChannelPollingFailed, message, null, innerException)
+        {
+        }
+    }
+
+    public class CanTransceiverMismatchException : CanKitException
+    {
+        public CanTransceiverMismatchException(Type expectedType, Type actualType)
+            : base(CanKitErrorCode.TransceiverMismatch,
+                $"Transceiver type mismatch. Expected '{expectedType.FullName}', but got '{actualType.FullName}'.")
+        {
+            ExpectedType = expectedType;
+            ActualType = actualType;
+        }
+
+        public Type ExpectedType { get; }
+
+        public Type ActualType { get; }
+    }
+
+    public class CanProviderMismatchException : CanKitException
+    {
+        public CanProviderMismatchException(Type expectedType, Type actualType)
+            : base(CanKitErrorCode.ProviderMismatch,
+                $"Provider type mismatch. Expected '{expectedType.FullName}', but got '{actualType.FullName}'.")
+        {
+            ExpectedType = expectedType;
+            ActualType = actualType;
+        }
+
+        public Type ExpectedType { get; }
+
+        public Type ActualType { get; }
+    }
+
+    public class CanFactoryDeviceMismatchException : CanKitException
+    {
+        public CanFactoryDeviceMismatchException(Type expectedType, Type actualType)
+            : base(CanKitErrorCode.FactoryDeviceMismatch,
+                $"Factory expects device type '{expectedType.FullName}', but received '{actualType.FullName}'.")
+        {
+            ExpectedType = expectedType;
+            ActualType = actualType;
+        }
+
+        public Type ExpectedType { get; }
+
+        public Type ActualType { get; }
+    }
+
+    public class CanFeatureNotSupportedException : CanKitException
+    {
+        public CanFeatureNotSupportedException(CanFeature requestedFeature, CanFeature availableFeatures)
+            : base(CanKitErrorCode.FeatureNotSupported,
+                $"Feature '{requestedFeature}' is not supported by the current device. Available features: {availableFeatures}.")
+        {
+            RequestedFeature = requestedFeature;
+            AvailableFeatures = availableFeatures;
+        }
+
+        public CanFeature RequestedFeature { get; }
+
+        public CanFeature AvailableFeatures { get; }
+    }
+
+    public class CanNativeCallException : CanChannelException
+    {
+        public CanNativeCallException(string operation, string message, uint? nativeErrorCode = null, Exception? innerException = null)
+            : base(CanKitErrorCode.NativeCallFailed, $"{message} (Operation: {operation})", nativeErrorCode, innerException)
+        {
+            Operation = operation;
+        }
+
+        public string Operation { get; }
+    }
+}

--- a/Pkuyo.CanKit.Net/Core/Utils/CanExtension.cs
+++ b/Pkuyo.CanKit.Net/Core/Utils/CanExtension.cs
@@ -1,13 +1,18 @@
-﻿using Pkuyo.CanKit.Net.Core.Definitions;
+using Pkuyo.CanKit.Net.Core.Definitions;
+using Pkuyo.CanKit.Net.Core.Exceptions;
 
 namespace Pkuyo.CanKit.Net.Core.Utils
 {
-
     public static class CanExtension
     {
         public static void CheckFeature(this CanFeature deviceFeatures, CanFeature checkFeature)
         {
-            
+            if ((deviceFeatures & checkFeature) == checkFeature)
+            {
+                return;
+            }
+
+            throw new CanFeatureNotSupportedException(checkFeature, deviceFeatures);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a reusable logging utility and comprehensive CAN-specific exception hierarchy
- tighten feature and option validation in the core session and configuration flows
- wire the ZLG transport through the new exception system and log native failures for easier diagnosis

## Testing
- `dotnet build CanKit.Net.sln` *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca11fe209c8322bc228f93fe03e7ad