### PR TITLE
docs: add comments for can definitions

### DIFF
--- a/Pkuyo.CanKit.Net.ZLG/Definitions/ZlgEnums.cs
+++ b/Pkuyo.CanKit.Net.ZLG/Definitions/ZlgEnums.cs
@@ -2,23 +2,74 @@ using System;
 
 namespace Pkuyo.CanKit.ZLG.Definitions;
 
+/// <summary>
+/// 中联 CAN 适配器报告的错误标志。
+/// </summary>
 [Flags]
 public enum ZlgErrorFlag
 {
+    /// <summary>
+    /// 未发生错误。
+    /// </summary>
     None                  = 0x0,
+    /// <summary>
+    /// 接收 FIFO 溢出。
+    /// </summary>
     FifoOverflow          = 0x1,
+    /// <summary>
+    /// 进入错误报警状态。
+    /// </summary>
     ErrAlarm              = 0x2,
+    /// <summary>
+    /// 进入错误被动状态。
+    /// </summary>
     ErrPassive            = 0x4,
+    /// <summary>
+    /// 发生仲裁丢失。
+    /// </summary>
     ArbitrationLost       = 0x8,
+    /// <summary>
+    /// 检测到总线错误。
+    /// </summary>
     BusErr                = 0x10,
+    /// <summary>
+    /// 控制器进入总线关闭状态。
+    /// </summary>
     BusOff                = 0x20,
+    /// <summary>
+    /// 缓冲区溢出。
+    /// </summary>
     BufferOverflow        = 0x40,
+    /// <summary>
+    /// 设备已打开。
+    /// </summary>
     DeviceOpened          = 0x100,
+    /// <summary>
+    /// 打开设备失败。
+    /// </summary>
     DeviceOpenErr         = 0x200,
+    /// <summary>
+    /// 设备未打开。
+    /// </summary>
     DeviceNotOpen         = 0x400,
+    /// <summary>
+    /// 设备缓冲区溢出。
+    /// </summary>
     DeviceBufferOverflow  = 0x800,
+    /// <summary>
+    /// 设备不存在。
+    /// </summary>
     DeviceNotExist        = 0x1000,
+    /// <summary>
+    /// 加载驱动失败。
+    /// </summary>
     LoadKernelErr         = 0x2000,
+    /// <summary>
+    /// 发送命令失败。
+    /// </summary>
     CmdFailed             = 0x4000,
+    /// <summary>
+    /// 系统内存不足。
+    /// </summary>
     OutOfMemory           = 0x8000
 }

--- a/Pkuyo.CanKit.Net.ZLG/Definitions/ZlgStructs.cs
+++ b/Pkuyo.CanKit.Net.ZLG/Definitions/ZlgStructs.cs
@@ -9,21 +9,35 @@ namespace System.Runtime.CompilerServices
 namespace Pkuyo.CanKit.ZLG.Definitions
 {
 
-    
+    /// <summary>
+    /// 中联 CAN 适配器错误信息的默认实现。
+    /// </summary>
     public record ZlgErrorInfo : ICanErrorInfo
     {
+        /// <summary>
+        /// 初始化错误信息并指定原始错误码。
+        /// </summary>
         public ZlgErrorInfo(uint rawErrorCode)
         {
             RawErrorCode = rawErrorCode;
         }
+        /// <inheritdoc />
         public FrameErrorKind Kind { get; init; }
+        /// <inheritdoc />
         public DateTime SystemTimestamp { get; init; }
+        /// <inheritdoc />
         public uint RawErrorCode { get; init; }
 
+        /// <summary>
+        /// 将原始错误码转换为中联定义的标志位枚举。
+        /// </summary>
         public ZlgErrorFlag ErrorCode => (ZlgErrorFlag)RawErrorCode;
-        
+
+        /// <inheritdoc />
         public ulong? TimeOffset { get; init; }
+        /// <inheritdoc />
         public FrameDirection Direction { get; init; }
+        /// <inheritdoc />
         public ICanFrame Frame { get; init; }
     }
 }

--- a/Pkuyo.CanKit.Net/Core/Definitions/CanEnums.cs
+++ b/Pkuyo.CanKit.Net/Core/Definitions/CanEnums.cs
@@ -2,7 +2,9 @@
 
 namespace Pkuyo.CanKit.Net.Core.Definitions
 {
-
+    /// <summary>
+    /// 表示 CAN 帧在传输过程中可能发生的错误类型。
+    /// </summary>
     public enum FrameErrorKind
     {
         None        = 0,         // 没有错误
@@ -16,13 +18,19 @@ namespace Pkuyo.CanKit.Net.Core.Definitions
         Unknown     = 65535
     }
 
+    /// <summary>
+    /// 表示数据帧的方向，是发送帧还是接收帧。
+    /// </summary>
     public enum FrameDirection
     {
         Unknown = 0,
         Tx,
         Rx
     }
-    
+
+    /// <summary>
+    /// 表示 CAN 通道当前的错误状态。
+    /// </summary>
     public enum ChannelErrorState
     {
         None        = 0,         // 没有错误
@@ -32,6 +40,9 @@ namespace Pkuyo.CanKit.Net.Core.Definitions
         BusRestart  = 4,         // 总线重启
     }
     
+    /// <summary>
+    /// 用于标识 CAN 帧类型的标志位，可组合使用。
+    /// </summary>
     [Flags]
     public enum CanFrameType : uint
     {
@@ -41,15 +52,20 @@ namespace Pkuyo.CanKit.Net.Core.Definitions
         Error      = 1 << 2,
         Any        = int.MaxValue
     }
-    
+
+    /// <summary>
+    /// 描述硬件支持的 CAN 协议模式。
+    /// </summary>
     public enum CanProtocolMode
     {
-        Can20 = 0,   
-        CanFd = 1,   
-        Merged = 2   
+        Can20 = 0,
+        CanFd = 1,
+        Merged = 2
     }
 
-    
+    /// <summary>
+    /// 描述适配器所支持的能力集，可组合使用。
+    /// </summary>
     [Flags]
     public enum CanFeature
     {
@@ -67,25 +83,37 @@ namespace Pkuyo.CanKit.Net.Core.Definitions
         BusUsage            = 1 << 8
     }
 
+    /// <summary>
+    /// 控制配置选项所属的阶段。
+    /// </summary>
     public enum CanOptionType
     {
         Init = 1,
         Runtime = 2
     }
 
+    /// <summary>
+    /// 发送失败后 CAN 控制器的重试策略。
+    /// </summary>
     public enum TxRetryPolicy : byte
     {
         NoRetry = 1,
         AlwaysRetry = 2,
     }
-    
+
+    /// <summary>
+    /// 表示 CAN 通道的工作模式，例如正常模式或只听模式。
+    /// </summary>
     public enum ChannelWorkMode : byte
     {
         Normal = 0,
         ListenOnly = 1,
         Echo = 2,
     }
-    
+
+    /// <summary>
+    /// 指示过滤规则使用标准帧 ID 还是扩展帧 ID。
+    /// </summary>
     public enum CanFilterIDType
     {
         Standard,

--- a/Pkuyo.CanKit.Net/Core/Definitions/CanFilter.cs
+++ b/Pkuyo.CanKit.Net/Core/Definitions/CanFilter.cs
@@ -2,18 +2,44 @@
 
 namespace Pkuyo.CanKit.Net.Core.Definitions
 {
+    /// <summary>
+    /// 表示一条 CAN 过滤规则的抽象基类。
+    /// </summary>
+    /// <param name="IdIdType">指示过滤规则使用的帧 ID 类型。</param>
     public abstract record FilterRule(CanFilterIDType IdIdType)
     {
+        /// <summary>
+        /// 通过设定 ID 范围来进行过滤的规则。
+        /// </summary>
+        /// <param name="From">允许的最小 ID。</param>
+        /// <param name="To">允许的最大 ID。</param>
         public sealed record Range(uint From, uint To) : FilterRule(CanFilterIDType.Standard)
         {
+            /// <summary>
+            /// 使用指定的 ID 类型初始化范围过滤规则。
+            /// </summary>
+            /// <param name="From">允许的最小 ID。</param>
+            /// <param name="To">允许的最大 ID。</param>
+            /// <param name="idType">标准帧或扩展帧。</param>
             public Range(uint From, uint To, CanFilterIDType idType) : this(From, To)
             {
                 IdIdType = idType;
             }
         }
 
+        /// <summary>
+        /// 通过设定验收码和掩码来匹配的过滤规则。
+        /// </summary>
+        /// <param name="AccCode">验收码。</param>
+        /// <param name="AccMask">掩码。</param>
         public sealed record Mask(uint AccCode, uint AccMask) : FilterRule(CanFilterIDType.Standard)
         {
+            /// <summary>
+            /// 使用指定的 ID 类型初始化掩码过滤规则。
+            /// </summary>
+            /// <param name="AccCode">验收码。</param>
+            /// <param name="AccMask">掩码。</param>
+            /// <param name="idType">标准帧或扩展帧。</param>
             public Mask(uint AccCode, uint AccMask, CanFilterIDType idType) : this(AccCode, AccMask)
             {
                 IdIdType = idType;
@@ -21,16 +47,29 @@ namespace Pkuyo.CanKit.Net.Core.Definitions
         }
     }
 
+    /// <summary>
+    /// 定义 CAN 过滤器对外暴露的最小契约。
+    /// </summary>
     public interface ICanFilter
     {
+        /// <summary>
+        /// 获取过滤器包含的过滤规则集合。
+        /// </summary>
         IReadOnlyList<FilterRule> FilterRules { get; }
     }
 
+    /// <summary>
+    /// 默认的 CAN 过滤器实现，内部维护可变的规则列表。
+    /// </summary>
     public class CanFilter : ICanFilter
     {
+        /// <summary>
+        /// 实际保存过滤规则的可变列表。
+        /// </summary>
         public List<FilterRule> filterRules = new();
 
+        /// <inheritdoc />
         public IReadOnlyList<FilterRule> FilterRules => filterRules;
     }
-    
+
 }

--- a/Pkuyo.CanKit.Net/Core/Definitions/CanFrame.cs
+++ b/Pkuyo.CanKit.Net/Core/Definitions/CanFrame.cs
@@ -3,28 +3,69 @@ using System.Text;
 
 namespace Pkuyo.CanKit.Net.Core.Definitions
 {
-    
-    
+
+    /// <summary>
+    /// 描述 CAN 帧的最小数据集合。
+    /// </summary>
     public interface ICanFrame
     {
+        /// <summary>
+        /// 获取帧的类型，例如经典 CAN 或 CAN FD。
+        /// </summary>
         CanFrameType FrameKind { get; }
+        /// <summary>
+        /// 获取或初始化包含所有标志位的原始 ID。
+        /// </summary>
         uint RawID { get; init; }
+        /// <summary>
+        /// 获取或初始化帧数据。
+        /// </summary>
         ReadOnlyMemory<byte> Data { get; init; }
+        /// <summary>
+        /// 获取帧的 DLC 值。
+        /// </summary>
         byte Dlc { get; }
+        /// <summary>
+        /// 获取或初始化剔除标志位后的实际 ID。
+        /// </summary>
         uint ID { get; init; }
     }
 
+    /// <summary>
+    /// 用于描述错误帧的附加信息。
+    /// </summary>
     public interface ICanErrorInfo
     {
+        /// <summary>
+        /// 获取错误类型。
+        /// </summary>
         FrameErrorKind Kind { get; init; }
-        
+
+        /// <summary>
+        /// 获取系统时间戳。
+        /// </summary>
         DateTime SystemTimestamp { get; init; }
+        /// <summary>
+        /// 获取原始错误码。
+        /// </summary>
         uint RawErrorCode { get; init; }
+        /// <summary>
+        /// 获取设备时间偏移量。
+        /// </summary>
         ulong? TimeOffset { get; init; }
+        /// <summary>
+        /// 获取错误帧的方向。
+        /// </summary>
         FrameDirection Direction { get; init; }
+        /// <summary>
+        /// 获取相关的原始帧。
+        /// </summary>
         ICanFrame Frame { get; init; }
     }
-    
+
+    /// <summary>
+    /// 对 CAN ID 的位操作进行了封装，方便统一处理。
+    /// </summary>
     internal static class CanIdBits
     {
         private const int EXT_BIT = 31;
@@ -32,7 +73,13 @@ namespace Pkuyo.CanKit.Net.Core.Definitions
         private const int ERR_BIT = 29;
         private const uint ID_MASK = 0x1FFFFFFF;
 
+        /// <summary>
+        /// 获取去掉标志位后的 ID。
+        /// </summary>
         public static uint GetId(uint raw) => raw & ID_MASK;
+        /// <summary>
+        /// 将 ID 写入原始值中。
+        /// </summary>
         public static uint SetId(uint raw, uint id) => (raw & ~ID_MASK) | (id & ID_MASK);
 
         public static bool Get(uint raw, int bit) => (raw & (1u << bit)) != 0;
@@ -46,9 +93,15 @@ namespace Pkuyo.CanKit.Net.Core.Definitions
         public static bool IsError(uint raw) => Get(raw, ERR_BIT);
         public static uint WithError(uint raw, bool v) => Set(raw, ERR_BIT, v);
     }
-    
+
+    /// <summary>
+    /// 经典 CAN 帧的值类型实现。
+    /// </summary>
     public readonly record struct CanClassicFrame : ICanFrame
     {
+        /// <summary>
+        /// 允许直接将经典帧用作发送数据结构。
+        /// </summary>
         public static implicit operator CanTransmitData(CanClassicFrame value)
         {
             return new CanTransmitData()
@@ -56,12 +109,22 @@ namespace Pkuyo.CanKit.Net.Core.Definitions
                 canFrame = value
             };
         }
+
+        /// <summary>
+        /// 通过原始 ID 和数据创建经典帧。
+        /// </summary>
         public CanClassicFrame(uint rawIDInit, ReadOnlyMemory<byte> dataInit = default)
         {
             RawID = rawIDInit;
             _data = dataInit;
         }
-        
+
+        /// <summary>
+        /// 通过标准/扩展 ID 创建经典帧。
+        /// </summary>
+        /// <param name="Id">不包含标志位的 ID。</param>
+        /// <param name="dataInit">帧数据。</param>
+        /// <param name="isExtendedFrame">指示是否为扩展帧。</param>
         public CanClassicFrame(uint Id, ReadOnlyMemory<byte> dataInit = default, bool isExtendedFrame = false)
         {
             ID = Id;
@@ -94,29 +157,41 @@ namespace Pkuyo.CanKit.Net.Core.Definitions
             init => RawID = CanIdBits.WithError(RawID, value);
         }
 
+        /// <summary>
+        /// 获取或设置帧数据，同时执行长度校验。
+        /// </summary>
         public  ReadOnlyMemory<byte> Data
         {
             get => _data;
             init =>  _data = Validate(value);
-            
+
         }
 
         public byte Dlc => (byte)Data.Length;
 
+        /// <summary>
+        /// 校验经典帧数据长度不超过 8 字节。
+        /// </summary>
         private static ReadOnlyMemory<byte> Validate(ReadOnlyMemory<byte> src)
         {
             if (src.Length > 8) throw new ArgumentOutOfRangeException(nameof(Data),
                 "Classic CAN frame data length cannot exceed 8 bytes.");
             return src;
         }
-        
+
         private readonly ReadOnlyMemory<byte> _data;
     }
-    
 
-    
+
+
+    /// <summary>
+    /// CAN FD 帧的值类型实现。
+    /// </summary>
     public readonly struct CanFdFrame : ICanFrame
     {
+        /// <summary>
+        /// 通过原始 ID 初始化 CAN FD 帧。
+        /// </summary>
         public CanFdFrame(uint rawIdInit, ReadOnlyMemory<byte> dataInit = default, bool BRS = false, bool ESI = false)
         {
             RawID = rawIdInit;
@@ -150,7 +225,13 @@ namespace Pkuyo.CanKit.Net.Core.Definitions
             init => RawID = CanIdBits.WithError(RawID, value);
         }
 
+        /// <summary>
+        /// 指示该帧在数据阶段是否启用了速率切换 (BRS)。
+        /// </summary>
         public bool BitRateSwitch { get; init; }
+        /// <summary>
+        /// 指示发送方是否处于错误状态 (ESI)。
+        /// </summary>
         public bool ErrorStateIndicator { get; init; }
 
         public ReadOnlyMemory<byte> Data
@@ -161,6 +242,9 @@ namespace Pkuyo.CanKit.Net.Core.Definitions
 
         public byte Dlc => LenToDlc(Data.Length);
 
+        /// <summary>
+        /// 将 DLC 值转换为实际的数据长度。
+        /// </summary>
         public static int DlcToLen(byte dlc)
             => dlc <= 8 ? dlc : dlc switch
             {
@@ -168,6 +252,9 @@ namespace Pkuyo.CanKit.Net.Core.Definitions
                 _ => throw new ArgumentOutOfRangeException(nameof(dlc))
             };
 
+        /// <summary>
+        /// 将数据长度转换为 DLC。
+        /// </summary>
         public static byte LenToDlc(int len)
         {
             if (len < 0 || len > 64) throw new ArgumentOutOfRangeException(nameof(len));
@@ -178,6 +265,9 @@ namespace Pkuyo.CanKit.Net.Core.Definitions
             };
         }
 
+        /// <summary>
+        /// 校验 CAN FD 数据长度不超过规范限制。
+        /// </summary>
         private static ReadOnlyMemory<byte> Validate(ReadOnlyMemory<byte> src)
         {
             _ = LenToDlc(src.Length); // 触发范围检查
@@ -186,7 +276,10 @@ namespace Pkuyo.CanKit.Net.Core.Definitions
 
         private readonly ReadOnlyMemory<byte> _data;
     }
-    
+
+    /// <summary>
+    /// 默认的错误信息实现，直接复用接口定义的字段。
+    /// </summary>
     public record DefaultCanErrorInfo(
         FrameErrorKind Kind,
         DateTime SystemTimestamp,
@@ -195,6 +288,6 @@ namespace Pkuyo.CanKit.Net.Core.Definitions
         FrameDirection Direction,
         ICanFrame Frame) : ICanErrorInfo
     {
-        
+
     }
 }

--- a/Pkuyo.CanKit.Net/Core/Definitions/CanStructs.cs
+++ b/Pkuyo.CanKit.Net/Core/Definitions/CanStructs.cs
@@ -11,21 +11,45 @@ namespace Pkuyo.CanKit.Net.Core.Definitions
 {
   
 
+    /// <summary>
+    /// 表示 CAN 总线的位时序配置，用于初始化设备参数。
+    /// </summary>
+    /// <param name="BaudRate">经典 CAN 的波特率。</param>
+    /// <param name="ArbitrationBitRate">仲裁段的比特率。</param>
+    /// <param name="DataBitRate">数据段的比特率。</param>
     public readonly record struct BitTiming(
         uint? BaudRate = null,
         uint? ArbitrationBitRate = null,
         uint? DataBitRate = null);
 
+    /// <summary>
+    /// 封装一次 CAN 数据发送所需的参数。
+    /// </summary>
     public record CanTransmitData
     {
+        /// <summary>
+        /// 待发送的帧内容。
+        /// </summary>
         public ICanFrame canFrame;
     }
 
+    /// <summary>
+    /// 表示一次 CAN 数据接收事件。
+    /// </summary>
     public record CanReceiveData
     {
+        /// <summary>
+        /// 接收到的帧内容。
+        /// </summary>
         public ICanFrame canFrame;
-        
+
+        /// <summary>
+        /// 设备提供的时间戳，通常为硬件计数值。
+        /// </summary>
         public UInt64 recvTimestamp;
+        /// <summary>
+        /// 记录接收时刻对应的系统时间。
+        /// </summary>
         public DateTime SystemTimestamp { get;  } = DateTime.Now;
     }
 }


### PR DESCRIPTION
## Summary
- add XML documentation comments to core CAN enums, frames, filters and helper records
- document ZLG specific enums and error info wrapper to clarify their usage

## Testing
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ca73081d248322834970482091f793