### PR TITLE
fix(zlg): fix cloud connection and name encoding 

### DIFF
--- a/src/adapters/CanKit.Adapter.ZLG/Native/ZLGAPI.Fake.cs
+++ b/src/adapters/CanKit.Adapter.ZLG/Native/ZLGAPI.Fake.cs
@@ -931,7 +931,7 @@ public static class ZLGCAN
           public const int ZCLOUD_MAX_DEVICES = 100;
         public const int ZCLOUD_MAX_CHANNEL = 16;
 
-        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi, Pack = 1)]
         public struct ZCLOUD_DEVINFO
         {
             public int            devIndex;
@@ -959,7 +959,7 @@ public static class ZLGCAN
             public ZCLOUD_CHNINFO[] channels;
         }
 
-        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi, Pack = 1)]
 
         public struct ZCLOUD_USER_DATA
         {

--- a/src/adapters/CanKit.Adapter.ZLG/Native/ZLGAPI.cs
+++ b/src/adapters/CanKit.Adapter.ZLG/Native/ZLGAPI.cs
@@ -468,7 +468,7 @@ namespace CanKit.Adapter.ZLG.Native
             public byte isDownload;
         }
 
-        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi, Pack = 1)]
         public struct ZCLOUD_DEVINFO
         {
             public int            devIndex;
@@ -496,7 +496,7 @@ namespace CanKit.Adapter.ZLG.Native
             public ZCLOUD_CHNINFO[] channels;
         }
 
-        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi, Pack = 1)]
 
         public struct ZCLOUD_USER_DATA
         {

--- a/src/adapters/CanKit.Adapter.ZLG/ZlgCanBus.cs
+++ b/src/adapters/CanKit.Adapter.ZLG/ZlgCanBus.cs
@@ -132,7 +132,12 @@ namespace CanKit.Adapter.ZLG
             _handle = handle;
             NativeHandle = new BusNativeHandle(_handle.DangerousGetHandle());
             ZlgErr.ThrowIfInvalid(handle, nameof(ZLGCAN.ZCAN_InitCAN));
-            Reset();
+
+            try
+            {
+                Reset();
+            } catch { /*ignore*/ }
+
             ApplyConfigAfterInit(options);
 
             ZlgErr.ThrowIfError(ZLGCAN.ZCAN_StartCAN(_handle), nameof(ZLGCAN.ZCAN_StartCAN), _handle);

--- a/src/adapters/CanKit.Adapter.ZLG/ZlgCloud.cs
+++ b/src/adapters/CanKit.Adapter.ZLG/ZlgCloud.cs
@@ -43,7 +43,7 @@ public class ZlgCloud : IDisposable
 
     public static Task<ZlgCloud> ConnectServerAsync(ZlgServerInfo serverInfo, string userName, string password)
     {
-        return Task<ZlgCloud>.Run(() => ConnectServerAsync(serverInfo, userName, password));
+        return Task<ZlgCloud>.Run(() => ConnectServer(serverInfo, userName, password));
     }
 
     /// <summary>Connects to the ZLG cloud server and returns a new session  (连接到 ZLG 云服务器并返回新会话)</summary>

--- a/src/core/CanKit.Abstractions/API/Common/Definitions/CanStructs.cs
+++ b/src/core/CanKit.Abstractions/API/Common/Definitions/CanStructs.cs
@@ -250,7 +250,7 @@ public readonly record struct CanReceiveData(CanFrame CanFrame)
     /// <summary>
     /// System time corresponding to this record. (该记录对应的系统时间。)
     /// </summary>
-    public DateTime SystemTimestamp { get; } = DateTime.Now;
+    public DateTime SystemTimestamp { get; init; } = DateTime.Now;
 
     /// <summary>
     /// Indicates whether this frame is a transmit echo/acknowledgment. (指示此帧是否为发送回显)


### PR DESCRIPTION
## Summary
fix cloud connection and name encoding

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Docs
- [x] Adapter-specific (PCAN/Kvaser/SocketCAN/ZLG)

## Checklist
- [x] Uses Conventional Commits in title (e.g., `feat(core): ...`)
- [x] Builds & tests pass locally (`dotnet build`, `dotnet test`)
- [x] Updated docs / samples if behavior changed
- [x] Linked related issues
