### PR TITLE
fix(socketcan): harden BCM periodic TX and tolerate missing ctrlmode

### DIFF
--- a/src/adapters/CanKit.Adapter.SocketCAN/Native/LibSocketCan.Fake.cs
+++ b/src/adapters/CanKit.Adapter.SocketCAN/Native/LibSocketCan.Fake.cs
@@ -89,7 +89,7 @@ namespace CanKit.Adapter.SocketCAN.Native
 
         public const uint IFLA_CAN_MAX = ((uint)IFLA_CAN.__IFLA_CAN_MAX - 1);
 
-        // Fake state store for vcan0/1/2
+        // Fake state store for vcan0/1/2/3/4
         private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, IfaceState> _state = new(StringComparer.Ordinal);
 
         private sealed class IfaceState
@@ -135,6 +135,30 @@ namespace CanKit.Adapter.SocketCAN.Native
 
         public static int can_get_ctrlmode(string name, out can_ctrlmode cm)
         {
+            // Real vcan interfaces can omit IFLA_CAN_CTRLMODE. libsocketcan
+            // returns -1 for that case without setting errno.
+            if (name == "vcan3")
+            {
+                Libc.SetErrno(0);
+                cm = default;
+                return -1;
+            }
+
+            // Existing interfaces can also fail for a real native error. Keep this
+            // distinct from the missing-ctrlmode case so capability tests verify it.
+            if (name == "vcan4")
+            {
+                Libc.SetErrno(Libc.EACCES);
+                cm = default;
+                return -1;
+            }
+
+            if (Libc.if_nametoindex(name) == 0)
+            {
+                cm = default;
+                return -1;
+            }
+
             var s = Get(name);
             cm = new can_ctrlmode { mask = s.CtrlMask, flags = s.CtrlFlags };
             return 0;

--- a/src/adapters/CanKit.Adapter.SocketCAN/Native/Libc.Fake.cs
+++ b/src/adapters/CanKit.Adapter.SocketCAN/Native/Libc.Fake.cs
@@ -374,12 +374,16 @@ internal static class Libc
             ["vcan0"] = new CanInterface("vcan0", 1),
             ["vcan1"] = new CanInterface("vcan1", 2),
             ["vcan2"] = new CanInterface("vcan2", 3),
+            ["vcan3"] = new CanInterface("vcan3", 4),
+            ["vcan4"] = new CanInterface("vcan4", 5),
         };
         public static readonly Dictionary<uint, CanInterface> IfacesByIndex = new Dictionary<uint, CanInterface>
         {
             [1] = IfacesByName["vcan0"],
             [2] = IfacesByName["vcan1"],
             [3] = IfacesByName["vcan2"],
+            [4] = IfacesByName["vcan3"],
+            [5] = IfacesByName["vcan4"],
         };
 
         [ThreadStatic]
@@ -997,6 +1001,8 @@ internal static class Libc
     }
 
     public static int Errno() => World.Errno;
+
+    public static void SetErrno(int errno) => World.Errno = errno;
 
     public static void ThrowErrno(string operation, string message, int errno)
     {

--- a/src/adapters/CanKit.Adapter.SocketCAN/Native/Libc.Fake.cs
+++ b/src/adapters/CanKit.Adapter.SocketCAN/Native/Libc.Fake.cs
@@ -27,6 +27,7 @@ internal static class Libc
 
     public const int EOPNOTSUPP = 95;
     public const int EPERM = 1;
+    public const int EINVAL = 22;
     public const int EINTR = 4;
     public const int EAGAIN = 11;
     public const int EACCES = 13;
@@ -330,6 +331,7 @@ internal static class Libc
         public int IfIndex;
         public readonly ConcurrentQueue<byte[]> Rx = new();
         public readonly List<EpollFd> Watchers = new();
+        public readonly HashSet<(uint CanId, bool IsFd)> TxOps = new();
         // Cancels the in-flight RunBcmJobAsync loop. Real Linux BCM stops emission on
         // TX_DELETE; without this, Fake jobs keep EmitFrame()'ing after Stop() and
         // pollute same-bitrate raw sockets used by parallel matrix tests.
@@ -602,6 +604,12 @@ internal static class Libc
                 var head = Unsafe.Read<bcm_msg_head>(buf);
                 if (head.opcode == TX_SETUP)
                 {
+                    if (head.nframes < 1)
+                    {
+                        World.Errno = EINVAL;
+                        return -1;
+                    }
+
                     // Interpret frame immediately following head if present
                     int headSize = Marshal.SizeOf<bcm_msg_head>();
                     var ptr = (byte*)buf + headSize;
@@ -610,9 +618,17 @@ internal static class Libc
                     var ifc = World.IfacesByIndex[(uint)b.IfIndex];
                     bool isFd = (head.flags & CAN_FD_FRAME) != 0;
                     int frameSize = isFd ? Marshal.SizeOf<canfd_frame>() : Marshal.SizeOf<can_frame>();
+                    if ((long)count != headSize + (long)head.nframes * frameSize)
+                    {
+                        World.Errno = EINVAL;
+                        return -1;
+                    }
+
                     var payload = new byte[frameSize];
                     if (head.nframes > 0 && (long)count >= headSize + frameSize)
                         Marshal.Copy((IntPtr)ptr, payload, 0, frameSize);
+                    lock (b.TxOps)
+                        b.TxOps.Add((canId, isFd));
 
                     // configure periodic loop
                     var period = ToTimeSpan(head.ival1);
@@ -631,6 +647,16 @@ internal static class Libc
                 }
                 else if (head.opcode == TX_DELETE)
                 {
+                    bool isFd = (head.flags & CAN_FD_FRAME) != 0;
+                    lock (b.TxOps)
+                    {
+                        if (!b.TxOps.Remove((head.can_id, isFd)))
+                        {
+                            World.Errno = EINVAL;
+                            return -1;
+                        }
+                    }
+
                     CancelBcmJob(b);
                     var done = new bcm_msg_head { opcode = TX_EXPIRED };
                     var bytes = StructureToBytes(done);
@@ -640,8 +666,18 @@ internal static class Libc
                 }
                 else if (head.opcode == TX_READ)
                 {
+                    bool isFd = (head.flags & CAN_FD_FRAME) != 0;
+                    lock (b.TxOps)
+                    {
+                        if (!b.TxOps.Contains((head.can_id, isFd)))
+                        {
+                            World.Errno = EINVAL;
+                            return -1;
+                        }
+                    }
+
                     // Return minimal TX_STATUS with 0 remaining (non-persistent for simplicity)
-                    var status = new bcm_msg_head { opcode = TX_STATUS, count = 0 };
+                    var status = new bcm_msg_head { opcode = TX_STATUS, flags = head.flags, count = 0 };
                     b.Rx.Enqueue(StructureToBytes(status));
                     return (long)Marshal.SizeOf<bcm_msg_head>();
                 }
@@ -946,6 +982,7 @@ internal static class Libc
         return errno switch
         {
             EAGAIN => "Resource temporarily unavailable",
+            EINVAL => "Invalid argument",
             EINTR => "Interrupted system call",
             EACCES => "Permission denied",
             EOPNOTSUPP => "Operation not supported",

--- a/src/adapters/CanKit.Adapter.SocketCAN/Native/Libc.Fake.cs
+++ b/src/adapters/CanKit.Adapter.SocketCAN/Native/Libc.Fake.cs
@@ -330,6 +330,10 @@ internal static class Libc
         public int IfIndex;
         public readonly ConcurrentQueue<byte[]> Rx = new();
         public readonly List<EpollFd> Watchers = new();
+        // Cancels the in-flight RunBcmJobAsync loop. Real Linux BCM stops emission on
+        // TX_DELETE; without this, Fake jobs keep EmitFrame()'ing after Stop() and
+        // pollute same-bitrate raw sockets used by parallel matrix tests.
+        public CancellationTokenSource JobCts;
     }
 
     private sealed class CanInterface
@@ -616,13 +620,18 @@ internal static class Libc
                     if (inf && period == TimeSpan.Zero) period = ToTimeSpan(head.ival2);
                     int remaining = inf ? -1 : (int)head.count;
 
+                    // Replace any previous job on this BCM socket (TX_SETUP is upsert).
+                    CancelBcmJob(b);
+                    var cts = new CancellationTokenSource();
+                    b.JobCts = cts;
+
                     // launch a background sender for this job
-                    _ = RunBcmJobAsync(b, canId, payload, isFd, period, remaining);
+                    _ = RunBcmJobAsync(b, canId, payload, isFd, period, remaining, cts.Token);
                     return (long)(headSize + (head.nframes > 0 ? frameSize : 0));
                 }
                 else if (head.opcode == TX_DELETE)
                 {
-                    // No persistent state stored; treat as best-effort stop by enqueuing a TX_EXPIRED signal
+                    CancelBcmJob(b);
                     var done = new bcm_msg_head { opcode = TX_EXPIRED };
                     var bytes = StructureToBytes(done);
                     b.Rx.Enqueue(bytes);
@@ -654,26 +663,59 @@ internal static class Libc
         }
     }
 
-    private static async Task RunBcmJobAsync(BcmSocketFd bc, uint canIdOrPayloadMarker, byte[] payload, bool isFd, TimeSpan period, int remaining)
+    private static void CancelBcmJob(BcmSocketFd bc)
+    {
+        var cts = bc.JobCts;
+        bc.JobCts = null;
+        if (cts is null) return;
+        try { cts.Cancel(); } catch { /* ignore */ }
+        try { cts.Dispose(); } catch { /* ignore */ }
+    }
+
+    private static async Task RunBcmJobAsync(
+        BcmSocketFd bc,
+        uint canIdOrPayloadMarker,
+        byte[] payload,
+        bool isFd,
+        TimeSpan period,
+        int remaining,
+        CancellationToken token)
     {
         // Encode id into payload if not provided
         _ = canIdOrPayloadMarker;
         if (period <= TimeSpan.Zero) period = TimeSpan.FromMilliseconds(1);
         int left = remaining;
-        while (left != 0)
+        try
         {
-            try
+            while (left != 0 && !token.IsCancellationRequested)
             {
-                EmitFrame(bc.IfIndex, payload, isFd, sourceFd: null);
-                if (left > 0) left--;
+                try
+                {
+                    EmitFrame(bc.IfIndex, payload, isFd, sourceFd: null);
+                    if (left > 0) left--;
+                }
+                catch { /* ignore */ }
+
+                try
+                {
+                    await System.Threading.Tasks.Task.Delay(period, token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
             }
-            catch { /* ignore */ }
-            await System.Threading.Tasks.Task.Delay(period).ConfigureAwait(false);
         }
-        // signal complete
-        var done = new bcm_msg_head { opcode = TX_EXPIRED };
-        bc.Rx.Enqueue(StructureToBytes(done));
-        SignalWatchers(bc);
+        finally
+        {
+            if (!token.IsCancellationRequested)
+            {
+                // Natural completion (finite count exhausted).
+                var done = new bcm_msg_head { opcode = TX_EXPIRED };
+                bc.Rx.Enqueue(StructureToBytes(done));
+                SignalWatchers(bc);
+            }
+        }
     }
 
     private static void EmitFrame(int srcIfIndex, byte[] payload, bool isFd, RawSocketFd sourceFd = null)

--- a/src/adapters/CanKit.Adapter.SocketCAN/SocketCanBus.cs
+++ b/src/adapters/CanKit.Adapter.SocketCAN/SocketCanBus.cs
@@ -621,7 +621,7 @@ public sealed class SocketCanBus : ICanBus<SocketCanBusRtConfigurator>, IOwnersh
         if (LibSocketCan.can_get_ctrlmode(ifName, out var ctrlMode) != Libc.OK)
         {
             var re = Libc.Errno();
-            if (re == Libc.EOPNOTSUPP)
+            if (re == 0 || re == Libc.EOPNOTSUPP)
             {
                 CanKitLogger.LogInformation($"SocketCanBus: {ifName} not support ctrlmode. Ignored socket can config.");
                 return;

--- a/src/adapters/CanKit.Adapter.SocketCAN/SocketCanProvider.cs
+++ b/src/adapters/CanKit.Adapter.SocketCAN/SocketCanProvider.cs
@@ -46,11 +46,14 @@ public sealed class SocketCanProvider : ICanModelProvider, ICanCapabilityProvide
         if (LibSocketCan.can_get_ctrlmode(busOptions.ChannelName, out var ctrlMode) != Libc.OK)
         {
             var re = Libc.Errno();
-            if (re == Libc.EOPNOTSUPP)
+            if ((re == 0 || re == Libc.EOPNOTSUPP) &&
+                Libc.if_nametoindex(busOptions.ChannelName) != 0)
             {
-                CanKitLogger.LogInformation($"SocketCanBus: {busOptions.ChannelName} not support ctrlmode. Ignored socket can config.");
+                CanKitLogger.LogInformation(
+                    $"SocketCanBus: {busOptions.ChannelName} does not expose ctrlmode. Using static capabilities.");
                 return new Capability(StaticFeatures);
             }
+
             Libc.ThrowErrno("can_get_ctrlmode", $"Failed to get ctrlmode for '{busOptions.ChannelName}'", re);
         }
 

--- a/src/adapters/CanKit.Adapter.SocketCAN/Utils/BCMPeriodicTx.cs
+++ b/src/adapters/CanKit.Adapter.SocketCAN/Utils/BCMPeriodicTx.cs
@@ -5,6 +5,7 @@ using CanKit.Abstractions.API.Can;
 using CanKit.Abstractions.API.Can.Definitions;
 using CanKit.Abstractions.API.Common;
 using CanKit.Abstractions.API.Common.Definitions;
+using CanKit.Abstractions.SPI.Common;
 using CanKit.Adapter.SocketCAN.Diagnostics;
 using CanKit.Adapter.SocketCAN.Native;
 using CanKit.Adapter.SocketCAN.Definitions;
@@ -28,7 +29,19 @@ public sealed class BCMPeriodicTx : IPeriodicTx
     private FileDescriptorHandle _epfd = new();
     private Libc.epoll_event[] _events = new Libc.epoll_event[4];
 
+    // Owned copy of the caller's frame. We must not keep a reference to the
+    // caller's memory owner: the BCM socket keeps re-emitting this payload for
+    // the lifetime of the timer, whereas the caller may dispose their own owner
+    // as soon as TransmitPeriodic returns. We rent a private buffer via the
+    // bus's IBufferAllocator and dispose it on Update (replace)/Stop/Dispose.
     private CanFrame _frame;
+
+    // Last observed remaining count from a TX_READ round-trip. Serves as a
+    // best-effort fallback whenever the kernel does not reply in time or
+    // replies with an unexpected opcode, so callers never observe a spurious
+    // EAGAIN throw from a healthy periodic transmission.
+    private int _lastKnownCount;
+
     private CancellationTokenSource? _readCts;
     private Task? _readTask;
 
@@ -85,9 +98,10 @@ public sealed class BCMPeriodicTx : IPeriodicTx
             nframes = 1
         };
 
-        _frame = frame;
+        _frame = DuplicateFrame(frame, configurator.BufferAllocator);
         RepeatCount = options.Repeat;
         Period = period;
+        _lastKnownCount = RepeatCount < 0 ? 0 : RepeatCount;
 
         var headSize = Marshal.SizeOf<Libc.bcm_msg_head>();
         var frameSize = (_frame.FrameKind is CanFrameType.CanFd) ? Marshal.SizeOf<Libc.canfd_frame>() : Marshal.SizeOf<Libc.can_frame>();
@@ -137,7 +151,13 @@ public sealed class BCMPeriodicTx : IPeriodicTx
         }
         if (frame is not null)
         {
-            _frame = frame.Value;
+            // TX-lease: rent an independent copy backed by our allocator, then
+            // dispose the previously-owned copy. The caller keeps ownership of
+            // the frame they passed in.
+            var newOwned = DuplicateFrame(frame.Value, _configurator.BufferAllocator);
+            var previous = _frame;
+            _frame = newOwned;
+            try { previous.Dispose(); } catch { /* ignore double-dispose from custom allocators */ }
         }
 
         var flags = 0u;
@@ -202,6 +222,20 @@ public sealed class BCMPeriodicTx : IPeriodicTx
         {
             if (_queryFd.IsInvalid) throw new CanBusDisposedException();
 
+            // The kernel replies to TX_READ asynchronously by enqueuing a TX_STATUS
+            // message onto the query socket. Because _queryFd is non-blocking, a
+            // naive read() right after write() races the kernel and returns EAGAIN,
+            // which the previous implementation surfaced as an unconditional
+            // ThrowErrno. We now:
+            //   1. Try a non-blocking read first (works when the reply is already
+            //      in the socket queue).
+            //   2. On EAGAIN, poll with a short timeout and retry.
+            //   3. Cap retries to bound total wait; skip stray non-TX_STATUS
+            //      messages and fall back to the last known count on
+            //      unrecoverable failures rather than raising to the caller.
+            const int PollTimeoutMs = 100;
+            const int MaxAttempts = 5;
+
             Libc.bcm_msg_head head = new Libc.bcm_msg_head
             {
                 opcode = Libc.TX_READ,
@@ -215,15 +249,46 @@ public sealed class BCMPeriodicTx : IPeriodicTx
                 if (Libc.write(_queryFd, &head, headSize) < 0)
                     Libc.ThrowErrno("write(BCM TX_READ)", "Failed to query BCM status");
 
-                var n = Libc.read(_queryFd, &head, headSize);
-                if (n != headSize)
-                    Libc.ThrowErrno("read(BCM TX_STATUS)", "Failed to read BCM status");
+                int fdInt = _queryFd.DangerousGetHandle().ToInt32();
 
-                if (head.opcode != Libc.TX_STATUS)
+                for (int attempt = 0; attempt < MaxAttempts; attempt++)
                 {
-                    // No-op; non-TX_STATUS is ignored
+                    var n = Libc.read(_queryFd, &head, headSize);
+                    if (n < 0)
+                    {
+                        var errno = Libc.Errno();
+                        if (errno == Libc.EAGAIN)
+                        {
+                            var pfd = new Libc.pollfd
+                            {
+                                fd = fdInt,
+                                events = Libc.POLLIN,
+                                revents = 0
+                            };
+                            int pr = Libc.poll(ref pfd, 1, PollTimeoutMs);
+                            if (pr < 0)
+                            {
+                                var perrno = Libc.Errno();
+                                if (perrno == Libc.EINTR) continue;
+                                return _lastKnownCount;
+                            }
+                            if (pr == 0) continue;
+                            if ((pfd.revents & Libc.POLLIN) == 0)
+                                return _lastKnownCount;
+                            continue;
+                        }
+                        if (errno == Libc.EINTR) continue;
+                        return _lastKnownCount;
+                    }
+
+                    if (n != headSize) continue;
+                    if (head.opcode != Libc.TX_STATUS) continue;
+
+                    _lastKnownCount = (int)head.count;
+                    return _lastKnownCount;
                 }
-                return (int)head.count;
+
+                return _lastKnownCount;
             }
         }
     }
@@ -265,6 +330,7 @@ public sealed class BCMPeriodicTx : IPeriodicTx
             _queryFd.Dispose();
             _cancelFd.Dispose();
             _epfd.Dispose();
+            try { _frame.Dispose(); } catch { /* built-in allocators tolerate redundant disposal */ }
         }
     }
 
@@ -461,6 +527,19 @@ public sealed class BCMPeriodicTx : IPeriodicTx
                 _ = Libc.fcntl(fd, Libc.F_SETFL, flags | Libc.O_NONBLOCK);
         }
         catch { /* ignore */ }
+    }
+
+    // Rents a private buffer from the bus allocator and copies the frame into
+    // it, so the returned frame's lifetime is fully decoupled from the caller's
+    // memory owner. Kind, ID and flags are preserved.
+    private static CanFrame DuplicateFrame(CanFrame frame, IBufferAllocator allocator)
+    {
+        var owner = allocator.Rent(frame.Data.Length);
+        frame.Data.Span.CopyTo(owner.Memory.Span);
+        var copy = frame.FrameKind is CanFrameType.CanFd
+            ? CanFrame.Fd(frame.ID, owner, ownMemory: allocator.FrameNeedDispose)
+            : CanFrame.Classic(frame.ID, owner, ownMemory: allocator.FrameNeedDispose);
+        return copy with { Flags = frame.Flags };
     }
 
 }

--- a/src/adapters/CanKit.Adapter.SocketCAN/Utils/BCMPeriodicTx.cs
+++ b/src/adapters/CanKit.Adapter.SocketCAN/Utils/BCMPeriodicTx.cs
@@ -20,13 +20,13 @@ public sealed class BCMPeriodicTx : IPeriodicTx
 {
 
     private readonly object _evtGate = new();
+    private readonly object _socketGate = new();
     private EventHandler? _completed;
 
     private SocketCanBusRtConfigurator _configurator;
     // Pre-initialize handles to invalid so a ctor failure path can safely
     // Dispose() them regardless of how far initialization progressed.
     private FileDescriptorHandle _fd = new();
-    private FileDescriptorHandle _queryFd = new();
     private FileDescriptorHandle _cancelFd = new();
     private FileDescriptorHandle _epfd = new();
     private Libc.epoll_event[] _events = new Libc.epoll_event[4];
@@ -72,15 +72,6 @@ public sealed class BCMPeriodicTx : IPeriodicTx
             if (Libc.connect(_fd, ref addr, saSize) < 0)
                 Libc.ThrowErrno("connect(SOCKADDR_CAN)", $"Failed to connect BCM socket to '{configurator.ChannelIndex}'");
             TrySetNonBlocking(_fd);
-
-
-            _queryFd = Libc.socket(Libc.AF_CAN, Libc.SOCK_DGRAM, Libc.CAN_BCM);
-            if (_queryFd.IsInvalid)
-                Libc.ThrowErrno("socket(AF_CAN, SOCK_DGRAM, CAN_BCM)", "Failed to create BCM query socket");
-            if (Libc.connect(_queryFd, ref addr, saSize) < 0)
-                Libc.ThrowErrno("connect(SOCKADDR_CAN)", $"Failed to connect BCM query socket to '{configurator.ChannelIndex}'");
-            TrySetNonBlocking(_queryFd);
-
 
             _cancelFd = Libc.eventfd(0, Libc.EFD_CLOEXEC | Libc.EFD_NONBLOCK);
             if (_cancelFd.IsInvalid)
@@ -157,7 +148,6 @@ public sealed class BCMPeriodicTx : IPeriodicTx
                 // from the bus allocator.
                 try { _frame.Dispose(); } catch { /* allocator-tolerant */ }
                 _fd.Dispose();
-                _queryFd.Dispose();
                 _cancelFd.Dispose();
                 _epfd.Dispose();
             }
@@ -198,13 +188,10 @@ public sealed class BCMPeriodicTx : IPeriodicTx
             try { previous.Dispose(); } catch { /* ignore double-dispose from custom allocators */ }
         }
 
-        var flags = 0u;
-        if (period is not null) flags |= Libc.SETTIMER;
+        var flags = Libc.TX_COUNTEVT;
+        if (period is not null || repeatCount is not null) flags |= Libc.SETTIMER;
         if (repeatCount is not null) flags |= Libc.STARTTIMER;
-
-        // only set CAN_FD_FRAME when frame has value
-        bool includeFrame = frame is not null;
-        if (includeFrame && _frame.FrameKind is CanFrameType.CanFd)
+        if (_frame.FrameKind is CanFrameType.CanFd)
             flags |= Libc.CAN_FD_FRAME;
 
         var head = new Libc.bcm_msg_head
@@ -215,39 +202,38 @@ public sealed class BCMPeriodicTx : IPeriodicTx
             ival1 = SocketCanUtils.ToTimeval((RepeatCount < 0) ? TimeSpan.Zero : Period), // repeat config times and stop
             ival2 = SocketCanUtils.ToTimeval((RepeatCount < 0) ? Period : TimeSpan.Zero), // immediately enter ival2 for infinite loop
             can_id = _frame.ToCanID(),
-            nframes = (uint)(includeFrame ? 1 : 0)
+            nframes = 1
         };
 
         var headSize = Marshal.SizeOf<Libc.bcm_msg_head>();
-        var maxFrameSize = Marshal.SizeOf<Libc.canfd_frame>();
-        var bufSize = headSize + (includeFrame ? maxFrameSize : 0);
+        var frameSize = _frame.FrameKind is CanFrameType.CanFd
+            ? Marshal.SizeOf<Libc.canfd_frame>()
+            : Marshal.SizeOf<Libc.can_frame>();
+        var bufSize = headSize + frameSize;
 
         unsafe
         {
             var buf = stackalloc byte[bufSize];
 
-            if (includeFrame)
+            if (_frame.FrameKind is CanFrameType.Can20)
             {
-                if (_frame.FrameKind is CanFrameType.Can20)
-                {
-                    var sz = Marshal.SizeOf<Libc.can_frame>();
-                    var fr = _frame.ToCanFrame();
-                    Unsafe.CopyBlockUnaligned(buf + headSize, &fr, (uint)sz);
-                }
-                else if (_frame.FrameKind is CanFrameType.Can20)
-                {
-                    var sz = Marshal.SizeOf<Libc.canfd_frame>();
-                    var fr = _frame.ToCanFdFrame();
-                    Unsafe.CopyBlockUnaligned(buf + headSize, &fr, (uint)sz);
-                }
-                else
-                {
-                    throw new NotSupportedException("protocol mode not supported");
-                }
+                var fr = _frame.ToCanFrame();
+                Unsafe.CopyBlockUnaligned(buf + headSize, &fr, (uint)frameSize);
+            }
+            else if (_frame.FrameKind is CanFrameType.CanFd)
+            {
+                var fr = _frame.ToCanFdFrame();
+                Unsafe.CopyBlockUnaligned(buf + headSize, &fr, (uint)frameSize);
+            }
+            else
+            {
+                throw new NotSupportedException("protocol mode not supported");
             }
 
             Unsafe.CopyBlockUnaligned(buf, &head, (uint)headSize);
-            var wrote = Libc.write(_fd, buf, (ulong)bufSize);
+            long wrote;
+            lock (_socketGate)
+                wrote = Libc.write(_fd, buf, (ulong)bufSize);
             if (wrote != bufSize)
                 Libc.ThrowErrno("write(BCM TX_SETUP)", "Failed to update BCM periodic transmission");
         }
@@ -258,13 +244,13 @@ public sealed class BCMPeriodicTx : IPeriodicTx
     {
         get
         {
-            if (_queryFd.IsInvalid) throw new CanBusDisposedException();
+            if (_fd.IsInvalid) throw new CanBusDisposedException();
 
             // The kernel replies to TX_READ asynchronously by enqueuing a TX_STATUS
-            // message onto the query socket. Because _queryFd is non-blocking, a
-            // naive read() right after write() races the kernel and returns EAGAIN,
-            // which the previous implementation surfaced as an unconditional
-            // ThrowErrno. We now:
+            // message onto the same BCM socket that owns the TX operation. Because
+            // the socket is non-blocking, a naive read() right after write() races
+            // the kernel and returns EAGAIN, which the previous implementation
+            // surfaced as an unconditional ThrowErrno. We now:
             //   1. Try a non-blocking read first (works when the reply is already
             //      in the socket queue).
             //   2. On EAGAIN, poll with a short timeout and retry.
@@ -277,63 +263,72 @@ public sealed class BCMPeriodicTx : IPeriodicTx
             Libc.bcm_msg_head head = new Libc.bcm_msg_head
             {
                 opcode = Libc.TX_READ,
+                flags = _frame.FrameKind is CanFrameType.CanFd ? Libc.CAN_FD_FRAME : 0u,
                 can_id = _frame.ToCanID(),
                 nframes = 0
             };
 
             unsafe
             {
-                var headSize = (uint)Marshal.SizeOf<Libc.bcm_msg_head>();
-                if (Libc.write(_queryFd, &head, headSize) < 0)
-                    Libc.ThrowErrno("write(BCM TX_READ)", "Failed to query BCM status");
-
-                int fdInt = _queryFd.DangerousGetHandle().ToInt32();
-
-                for (int attempt = 0; attempt < MaxAttempts; attempt++)
+                lock (_socketGate)
                 {
-                    var n = Libc.read(_queryFd, &head, headSize);
-                    if (n < 0)
+                    var headSize = (uint)Marshal.SizeOf<Libc.bcm_msg_head>();
+                    if (Libc.write(_fd, &head, headSize) < 0)
+                        return _lastKnownCount;
+
+                    int fdInt = _fd.DangerousGetHandle().ToInt32();
+
+                    for (int attempt = 0; attempt < MaxAttempts; attempt++)
                     {
-                        var errno = Libc.Errno();
-                        if (errno == Libc.EAGAIN)
+                        var n = Libc.read(_fd, &head, headSize);
+                        if (n < 0)
                         {
-                            var pfd = new Libc.pollfd
+                            var errno = Libc.Errno();
+                            if (errno == Libc.EAGAIN)
                             {
-                                fd = fdInt,
-                                events = Libc.POLLIN,
-                                revents = 0
-                            };
-                            int pr = Libc.poll(ref pfd, 1, PollTimeoutMs);
-                            if (pr < 0)
-                            {
-                                var perrno = Libc.Errno();
-                                if (perrno == Libc.EINTR) continue;
-                                return _lastKnownCount;
+                                var pfd = new Libc.pollfd
+                                {
+                                    fd = fdInt,
+                                    events = Libc.POLLIN,
+                                    revents = 0
+                                };
+                                int pr = Libc.poll(ref pfd, 1, PollTimeoutMs);
+                                if (pr < 0)
+                                {
+                                    var perrno = Libc.Errno();
+                                    if (perrno == Libc.EINTR) continue;
+                                    return _lastKnownCount;
+                                }
+                                if (pr == 0) continue;
+                                if ((pfd.revents & Libc.POLLIN) == 0)
+                                    return _lastKnownCount;
+                                continue;
                             }
-                            if (pr == 0) continue;
-                            if ((pfd.revents & Libc.POLLIN) == 0)
-                                return _lastKnownCount;
+                            if (errno == Libc.EINTR) continue;
+                            return _lastKnownCount;
+                        }
+
+                        if (n != headSize) continue;
+                        if (head.opcode == Libc.TX_EXPIRED)
+                        {
+                            try { _completed?.Invoke(this, EventArgs.Empty); } catch { /* ignore */ }
                             continue;
                         }
-                        if (errno == Libc.EINTR) continue;
+                        if (head.opcode != Libc.TX_STATUS) continue;
+
+                        // BCM kernel encodes an infinite job's remaining count as
+                        // 0. The IPeriodicTx contract instead reserves -1 for
+                        // infinite (0 means "finite job that has finished"), so
+                        // remap the value based on the configured RepeatCount.
+                        if (RepeatCount < 0 && head.count == 0)
+                            _lastKnownCount = -1;
+                        else
+                            _lastKnownCount = (int)head.count;
                         return _lastKnownCount;
                     }
 
-                    if (n != headSize) continue;
-                    if (head.opcode != Libc.TX_STATUS) continue;
-
-                    // BCM kernel encodes an infinite job's remaining count as
-                    // 0. The IPeriodicTx contract instead reserves -1 for
-                    // infinite (0 means "finite job that has finished"), so
-                    // remap the value based on the configured RepeatCount.
-                    if (RepeatCount < 0 && head.count == 0)
-                        _lastKnownCount = -1;
-                    else
-                        _lastKnownCount = (int)head.count;
                     return _lastKnownCount;
                 }
-
-                return _lastKnownCount;
             }
         }
     }
@@ -347,7 +342,7 @@ public sealed class BCMPeriodicTx : IPeriodicTx
             var head = new Libc.bcm_msg_head
             {
                 opcode = Libc.TX_DELETE,
-                flags = 0,
+                flags = _frame.FrameKind is CanFrameType.CanFd ? Libc.CAN_FD_FRAME : 0u,
                 count = 0,
                 ival1 = default,
                 ival2 = default,
@@ -359,7 +354,9 @@ public sealed class BCMPeriodicTx : IPeriodicTx
             {
                 var buf = stackalloc byte[size];
                 Unsafe.CopyBlockUnaligned(buf, &head, (uint)size);
-                var wrote = Libc.write(_fd, buf, (ulong)size);
+                long wrote;
+                lock (_socketGate)
+                    wrote = Libc.write(_fd, buf, (ulong)size);
                 if (wrote != size)
                     Libc.ThrowErrno("write(BCM TX_DELETE)", "Failed to delete BCM periodic transmission");
             }
@@ -372,7 +369,6 @@ public sealed class BCMPeriodicTx : IPeriodicTx
         {
             StopMonitor(true);
             _fd.Dispose();
-            _queryFd.Dispose();
             _cancelFd.Dispose();
             _epfd.Dispose();
             try { _frame.Dispose(); } catch { /* built-in allocators tolerate redundant disposal */ }
@@ -536,7 +532,9 @@ public sealed class BCMPeriodicTx : IPeriodicTx
 
                 if ((_events[i].events & Libc.EPOLLIN) != 0)
                 {
-                    long r = Libc.read(_fd, buf, (ulong)headSize);
+                    long r;
+                    lock (_socketGate)
+                        r = Libc.read(_fd, buf, (ulong)headSize);
                     if (r < 0)
                     {
                         var errno = Libc.Errno();

--- a/src/adapters/CanKit.Adapter.SocketCAN/Utils/BCMPeriodicTx.cs
+++ b/src/adapters/CanKit.Adapter.SocketCAN/Utils/BCMPeriodicTx.cs
@@ -23,9 +23,11 @@ public sealed class BCMPeriodicTx : IPeriodicTx
     private EventHandler? _completed;
 
     private SocketCanBusRtConfigurator _configurator;
-    private FileDescriptorHandle _fd;
-    private FileDescriptorHandle _queryFd;
-    private FileDescriptorHandle _cancelFd;
+    // Pre-initialize handles to invalid so a ctor failure path can safely
+    // Dispose() them regardless of how far initialization progressed.
+    private FileDescriptorHandle _fd = new();
+    private FileDescriptorHandle _queryFd = new();
+    private FileDescriptorHandle _cancelFd = new();
     private FileDescriptorHandle _epfd = new();
     private Libc.epoll_event[] _events = new Libc.epoll_event[4];
 
@@ -53,82 +55,112 @@ public sealed class BCMPeriodicTx : IPeriodicTx
     {
         _configurator = configurator;
 
-        _fd = Libc.socket(Libc.AF_CAN, Libc.SOCK_DGRAM, Libc.CAN_BCM);
-        if (_fd.IsInvalid)
-            Libc.ThrowErrno("socket(AF_CAN, SOCK_DGRAM, CAN_BCM)", "Failed to create BCM socket");
-
-        var addr = new Libc.sockaddr_can { can_family = (ushort)Libc.AF_CAN, can_ifindex = configurator.ChannelIndex };
-        var saSize = Marshal.SizeOf<Libc.sockaddr_can>();
-        if (Libc.connect(_fd, ref addr, saSize) < 0)
-            Libc.ThrowErrno("connect(SOCKADDR_CAN)", $"Failed to connect BCM socket to '{configurator.ChannelIndex}'");
-        TrySetNonBlocking(_fd);
-
-
-        _queryFd = Libc.socket(Libc.AF_CAN, Libc.SOCK_DGRAM, Libc.CAN_BCM);
-        if (_queryFd.IsInvalid)
-            Libc.ThrowErrno("socket(AF_CAN, SOCK_DGRAM, CAN_BCM)", "Failed to create BCM query socket");
-        if (Libc.connect(_queryFd, ref addr, saSize) < 0)
-            Libc.ThrowErrno("connect(SOCKADDR_CAN)", $"Failed to connect BCM query socket to '{configurator.ChannelIndex}'");
-        TrySetNonBlocking(_queryFd);
-
-
-        _cancelFd = Libc.eventfd(0, Libc.EFD_CLOEXEC | Libc.EFD_NONBLOCK);
-        if (_cancelFd.IsInvalid)
-            Libc.ThrowErrno("eventfd", "Failed to create cancel eventfd");
-
-        if (frame.FrameKind is CanFrameType.Can20 && configurator.ProtocolMode != CanProtocolMode.Can20)
-            throw new CanFeatureNotSupportedException(CanFeature.CanClassic, configurator.Features);
-        if (frame.FrameKind is CanFrameType.CanFd && configurator.ProtocolMode != CanProtocolMode.CanFd)
-            throw new CanFeatureNotSupportedException(CanFeature.CanFd, configurator.Features);
-
-
-        var period = options.Period <= TimeSpan.Zero ? TimeSpan.FromMilliseconds(1) : options.Period;
-        var ival1 = (options.Repeat < 0) ? TimeSpan.Zero : period; // repeat config times and stop
-        var ival2 = (options.Repeat < 0) ? period : TimeSpan.Zero; // immediately enter ival2 infinite inf loop
-
-        var head = new Libc.bcm_msg_head
+        // Track construction success so we can dispose any partially-acquired
+        // native resources (sockets, eventfd, duplicated frame) on failure.
+        // Without this, an exception after the frame copy — e.g. an errno
+        // throw from write(TX_SETUP) — would leak the rented copy and the FDs,
+        // since a ctor that throws does not run the caller's Dispose.
+        var success = false;
+        try
         {
-            opcode = Libc.TX_SETUP,
-            flags = Libc.SETTIMER | Libc.STARTTIMER | Libc.TX_COUNTEVT
-                    | (frame.FrameKind is CanFrameType.CanFd ? Libc.CAN_FD_FRAME : 0u),
-            count = (options.Repeat < 0) ? 0u : (uint)options.Repeat,
-            ival1 = SocketCanUtils.ToTimeval(ival1),
-            ival2 = SocketCanUtils.ToTimeval(ival2),
-            can_id = frame.ToCanID(),
-            nframes = 1
-        };
+            _fd = Libc.socket(Libc.AF_CAN, Libc.SOCK_DGRAM, Libc.CAN_BCM);
+            if (_fd.IsInvalid)
+                Libc.ThrowErrno("socket(AF_CAN, SOCK_DGRAM, CAN_BCM)", "Failed to create BCM socket");
 
-        _frame = DuplicateFrame(frame, configurator.BufferAllocator);
-        RepeatCount = options.Repeat;
-        Period = period;
-        _lastKnownCount = RepeatCount < 0 ? 0 : RepeatCount;
+            var addr = new Libc.sockaddr_can { can_family = (ushort)Libc.AF_CAN, can_ifindex = configurator.ChannelIndex };
+            var saSize = Marshal.SizeOf<Libc.sockaddr_can>();
+            if (Libc.connect(_fd, ref addr, saSize) < 0)
+                Libc.ThrowErrno("connect(SOCKADDR_CAN)", $"Failed to connect BCM socket to '{configurator.ChannelIndex}'");
+            TrySetNonBlocking(_fd);
 
-        var headSize = Marshal.SizeOf<Libc.bcm_msg_head>();
-        var frameSize = (_frame.FrameKind is CanFrameType.CanFd) ? Marshal.SizeOf<Libc.canfd_frame>() : Marshal.SizeOf<Libc.can_frame>();
 
-        unsafe
+            _queryFd = Libc.socket(Libc.AF_CAN, Libc.SOCK_DGRAM, Libc.CAN_BCM);
+            if (_queryFd.IsInvalid)
+                Libc.ThrowErrno("socket(AF_CAN, SOCK_DGRAM, CAN_BCM)", "Failed to create BCM query socket");
+            if (Libc.connect(_queryFd, ref addr, saSize) < 0)
+                Libc.ThrowErrno("connect(SOCKADDR_CAN)", $"Failed to connect BCM query socket to '{configurator.ChannelIndex}'");
+            TrySetNonBlocking(_queryFd);
+
+
+            _cancelFd = Libc.eventfd(0, Libc.EFD_CLOEXEC | Libc.EFD_NONBLOCK);
+            if (_cancelFd.IsInvalid)
+                Libc.ThrowErrno("eventfd", "Failed to create cancel eventfd");
+
+            if (frame.FrameKind is CanFrameType.Can20 && configurator.ProtocolMode != CanProtocolMode.Can20)
+                throw new CanFeatureNotSupportedException(CanFeature.CanClassic, configurator.Features);
+            if (frame.FrameKind is CanFrameType.CanFd && configurator.ProtocolMode != CanProtocolMode.CanFd)
+                throw new CanFeatureNotSupportedException(CanFeature.CanFd, configurator.Features);
+
+
+            var period = options.Period <= TimeSpan.Zero ? TimeSpan.FromMilliseconds(1) : options.Period;
+            var ival1 = (options.Repeat < 0) ? TimeSpan.Zero : period; // repeat config times and stop
+            var ival2 = (options.Repeat < 0) ? period : TimeSpan.Zero; // immediately enter ival2 infinite inf loop
+
+            var head = new Libc.bcm_msg_head
+            {
+                opcode = Libc.TX_SETUP,
+                flags = Libc.SETTIMER | Libc.STARTTIMER | Libc.TX_COUNTEVT
+                        | (frame.FrameKind is CanFrameType.CanFd ? Libc.CAN_FD_FRAME : 0u),
+                count = (options.Repeat < 0) ? 0u : (uint)options.Repeat,
+                ival1 = SocketCanUtils.ToTimeval(ival1),
+                ival2 = SocketCanUtils.ToTimeval(ival2),
+                can_id = frame.ToCanID(),
+                nframes = 1
+            };
+
+            _frame = DuplicateFrame(frame, configurator.BufferAllocator);
+            RepeatCount = options.Repeat;
+            Period = period;
+            // IPeriodicTx contract: RemainingCount == -1 signals infinite. The
+            // BCM kernel uses count==0 for infinite jobs, so we cannot round-
+            // trip that value through _lastKnownCount without losing the
+            // infinite distinction (see RemainingCount getter and Update).
+            _lastKnownCount = RepeatCount < 0 ? -1 : RepeatCount;
+
+            var headSize = Marshal.SizeOf<Libc.bcm_msg_head>();
+            var frameSize = (_frame.FrameKind is CanFrameType.CanFd) ? Marshal.SizeOf<Libc.canfd_frame>() : Marshal.SizeOf<Libc.can_frame>();
+
+            unsafe
+            {
+                var buf = stackalloc byte[headSize + frameSize];
+
+                if (_frame.FrameKind is CanFrameType.Can20)
+                {
+                    var fr = _frame.ToCanFrame();
+                    Unsafe.CopyBlockUnaligned(buf + headSize, &fr, (uint)frameSize);
+                }
+                else if (_frame.FrameKind is CanFrameType.CanFd)
+                {
+                    var fr = _frame.ToCanFdFrame();
+                    Unsafe.CopyBlockUnaligned(buf + headSize, &fr, (uint)frameSize);
+                }
+                else
+                {
+                    throw new NotSupportedException("protocol mode not supported");
+                }
+
+                Unsafe.CopyBlockUnaligned(buf, &head, (uint)headSize);
+                var wrote = Libc.write(_fd, buf, (ulong)(headSize + frameSize));
+                if (wrote != headSize + frameSize)
+                    Libc.ThrowErrno("write(BCM TX_SETUP)", "Failed to setup BCM periodic transmission");
+            }
+
+            success = true;
+        }
+        finally
         {
-            var buf = stackalloc byte[headSize + frameSize];
-
-            if (_frame.FrameKind is CanFrameType.Can20)
+            if (!success)
             {
-                var fr = _frame.ToCanFrame();
-                Unsafe.CopyBlockUnaligned(buf + headSize, &fr, (uint)frameSize);
+                // _frame is a struct; if we threw before the copy assignment it
+                // stays default(CanFrame) with a null _memoryOwner, so Dispose
+                // is a no-op. Afterwards, this releases the rental we took
+                // from the bus allocator.
+                try { _frame.Dispose(); } catch { /* allocator-tolerant */ }
+                _fd.Dispose();
+                _queryFd.Dispose();
+                _cancelFd.Dispose();
+                _epfd.Dispose();
             }
-            else if (_frame.FrameKind is CanFrameType.CanFd)
-            {
-                var fr = _frame.ToCanFdFrame();
-                Unsafe.CopyBlockUnaligned(buf + headSize, &fr, (uint)frameSize);
-            }
-            else
-            {
-                throw new NotSupportedException("protocol mode not supported");
-            }
-
-            Unsafe.CopyBlockUnaligned(buf, &head, (uint)headSize);
-            var wrote = Libc.write(_fd, buf, (ulong)(headSize + frameSize));
-            if (wrote != headSize + frameSize)
-                Libc.ThrowErrno("write(BCM TX_SETUP)", "Failed to setup BCM periodic transmission");
         }
     }
 
@@ -144,6 +176,12 @@ public sealed class BCMPeriodicTx : IPeriodicTx
         {
             RepeatCount = repeatCount.Value;
             newCount = RepeatCount;
+            // Keep the cached remaining-count in sync with what we just
+            // programmed into the kernel. Without this, a subsequent
+            // RemainingCount call before TX_STATUS arrives (or on a fallback
+            // path) would return a stale value from before the reprogramming.
+            // Follow the IPeriodicTx contract: -1 signals infinite, never 0.
+            _lastKnownCount = RepeatCount < 0 ? -1 : RepeatCount;
         }
         else
         {
@@ -284,7 +322,14 @@ public sealed class BCMPeriodicTx : IPeriodicTx
                     if (n != headSize) continue;
                     if (head.opcode != Libc.TX_STATUS) continue;
 
-                    _lastKnownCount = (int)head.count;
+                    // BCM kernel encodes an infinite job's remaining count as
+                    // 0. The IPeriodicTx contract instead reserves -1 for
+                    // infinite (0 means "finite job that has finished"), so
+                    // remap the value based on the configured RepeatCount.
+                    if (RepeatCount < 0 && head.count == 0)
+                        _lastKnownCount = -1;
+                    else
+                        _lastKnownCount = (int)head.count;
                     return _lastKnownCount;
                 }
 

--- a/tests/CanKit.Tests/TestCases/SocketCanBcmOwnershipTests.cs
+++ b/tests/CanKit.Tests/TestCases/SocketCanBcmOwnershipTests.cs
@@ -154,6 +154,53 @@ public class SocketCanBcmOwnershipTests
     }
 
     [Fact]
+    public void RemainingCount_For_Infinite_Job_Reports_Negative_One()
+    {
+        if (!ShouldRun()) return;
+
+        // IPeriodicTx contract: RemainingCount == -1 iff the job is infinite.
+        // The BCM kernel uses count==0 for infinite jobs; without the explicit
+        // remap, callers would observe 0 here and mistake an infinite job for
+        // a completed finite one.
+        using var bus = OpenClassic(BcmOnlyEndpoint, new DefaultBufferAllocator());
+        using var frame = CanFrame.Classic(0x456, new byte[] { 1, 2, 3 });
+
+        using var handle = bus.TransmitPeriodic(frame, new PeriodicTxOptions(TimeSpan.FromMilliseconds(20), -1));
+
+        handle.RepeatCount.Should().Be(-1, "the caller requested an infinite periodic job.");
+
+        // Initial read (from _lastKnownCount seed and/or fresh TX_STATUS).
+        handle.RemainingCount.Should().Be(-1,
+            "an infinite BCM job must never report 0 remaining (that means 'finished').");
+
+        // After the timer ticks a few times the kernel-reported count is still 0;
+        // the mapping to -1 must persist.
+        System.Threading.Thread.Sleep(60);
+        handle.RemainingCount.Should().Be(-1,
+            "infinite semantics must be stable across TX_STATUS refreshes.");
+    }
+
+    [Fact]
+    public void Update_To_Infinite_Repaves_Remaining_Count_As_Negative_One()
+    {
+        if (!ShouldRun()) return;
+
+        // Guard the Update-side of the invariant: switching a finite job to
+        // infinite via Update(repeatCount: -1) must refresh the cached
+        // RemainingCount so it reflects the new contract immediately, without
+        // waiting for a TX_STATUS round-trip.
+        using var bus = OpenClassic(BcmOnlyEndpoint, new DefaultBufferAllocator());
+        using var frame = CanFrame.Classic(0x789, new byte[] { 4, 5, 6 });
+
+        using var handle = bus.TransmitPeriodic(frame, new PeriodicTxOptions(TimeSpan.FromMilliseconds(20), 5));
+
+        handle.Update(repeatCount: -1);
+        handle.RepeatCount.Should().Be(-1);
+        handle.RemainingCount.Should().Be(-1,
+            "Update(repeatCount: -1) must update _lastKnownCount to -1, not leave a stale finite value or a raw 0.");
+    }
+
+    [Fact]
     public async Task Update_And_Stop_Are_Safe_After_Caller_Disposes_Their_Frame()
     {
         if (!ShouldRun()) return;

--- a/tests/CanKit.Tests/TestCases/SocketCanBcmOwnershipTests.cs
+++ b/tests/CanKit.Tests/TestCases/SocketCanBcmOwnershipTests.cs
@@ -31,7 +31,7 @@ namespace CanKit.Tests.TestCases;
 /// failures.
 ///
 /// Fake caveat: the Fake backend replies to TX_READ synchronously by
-/// pre-enqueuing a TX_STATUS onto the query socket, so the read() in
+/// pre-enqueuing a TX_STATUS onto the owning BCM socket, so the read() in
 /// RemainingCount does not actually hit EAGAIN under Fake. These tests
 /// therefore cannot fully exercise the poll() / retry branch we added —
 /// only the "TX_READ never throws" contract. The poll()/EAGAIN retry loop
@@ -90,6 +90,12 @@ public class SocketCanBcmOwnershipTests
             .BufferAllocator(busAllocator)
             .SetAsyncBufferCapacity(64));
 
+    private static ICanBus OpenFd(string endpoint)
+        => CanBus.Open(endpoint, cfg => cfg
+            .SetProtocolMode(CanProtocolMode.CanFd)
+            .Fd(500_000, 2_000_000)
+            .SetAsyncBufferCapacity(64));
+
     [Fact]
     public void TransmitPeriodic_Does_Not_Keep_Reference_To_Caller_Buffer()
     {
@@ -146,11 +152,27 @@ public class SocketCanBcmOwnershipTests
 
         // Pre-fix: this would throw with EAGAIN from ThrowErrno("read(BCM TX_STATUS)")
         // whenever the kernel hadn't yet enqueued a TX_STATUS reply on the non-blocking
-        // query socket. Post-fix: the read races the reply, on EAGAIN we poll+retry
+        // BCM socket. Post-fix: the read races the reply, on EAGAIN we poll+retry
         // up to MaxAttempts, and on unrecoverable failure we fall back to the cached
         // count instead of raising. Under Fake this exercises the happy path only.
         Action act = () => _ = handle.RemainingCount;
         act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Fd_RemainingCount_And_Update_Use_The_Owning_Bcm_Operation()
+    {
+        if (!ShouldRun()) return;
+
+        using var bus = OpenFd(BcmOnlyEndpoint);
+        using var frame = CanFrame.Fd(0x456, new byte[] { 1, 2, 3 }, true);
+        using var handle = bus.TransmitPeriodic(frame, new PeriodicTxOptions(TimeSpan.FromMilliseconds(10), 3));
+
+        Action query = () => _ = handle.RemainingCount;
+        Action update = () => handle.Update(period: TimeSpan.FromMilliseconds(20));
+
+        query.Should().NotThrow();
+        update.Should().NotThrow();
     }
 
     [Fact]

--- a/tests/CanKit.Tests/TestCases/SocketCanBcmOwnershipTests.cs
+++ b/tests/CanKit.Tests/TestCases/SocketCanBcmOwnershipTests.cs
@@ -1,0 +1,242 @@
+using System;
+using System.Buffers;
+using System.Threading;
+using System.Threading.Tasks;
+using CanKit.Abstractions.API.Can;
+using CanKit.Abstractions.API.Can.Definitions;
+using CanKit.Abstractions.API.Common;
+using CanKit.Abstractions.API.Common.Definitions;
+using CanKit.Abstractions.SPI.Common;
+using CanKit.Core;
+using CanKit.Core.Definitions;
+using FluentAssertions;
+using Xunit;
+
+namespace CanKit.Tests.TestCases;
+
+/// <summary>
+/// Focused unit tests for SocketCAN BCM periodic-TX frame ownership and
+/// RemainingCount robustness.
+///
+/// These tests self-skip unless the SocketCAN adapter is the target of this
+/// CI job (CANKIT_TEST_ADAPTERS=CanKit.Adapter.SocketCAN), matching the
+/// self-skip convention of the adapter test matrix. Under -c Fake the
+/// SocketCAN adapter loads its in-memory Libc.Fake backend, which lets us
+/// exercise the BCM code paths without vcan or a real kernel.
+///
+/// Important: use <see cref="BcmOnlyEndpoint"/> (<c>vcan2</c>) rather than the
+/// shared <c>vcan0</c>/<c>vcan1</c> pair that matrix throughput tests open.
+/// Infinite BCM jobs on Fake still inject frames onto the bound iface; running
+/// them on vcan0 races parallel FD batch tests and produces spurious Lost-frame
+/// failures.
+///
+/// Fake caveat: the Fake backend replies to TX_READ synchronously by
+/// pre-enqueuing a TX_STATUS onto the query socket, so the read() in
+/// RemainingCount does not actually hit EAGAIN under Fake. These tests
+/// therefore cannot fully exercise the poll() / retry branch we added —
+/// only the "TX_READ never throws" contract. The poll()/EAGAIN retry loop
+/// is exercised on real Linux/vcan hardware CI.
+/// </summary>
+[Collection("SocketCanBcmOwnership")]
+public class SocketCanBcmOwnershipTests
+{
+    /// <summary>Dedicated Fake iface so BCM emissions never collide with vcan0/vcan1 matrix tests.</summary>
+    private const string BcmOnlyEndpoint = "socketcan://vcan2";
+
+    private static bool ShouldRun()
+    {
+        var env = Environment.GetEnvironmentVariable("CANKIT_TEST_ADAPTERS");
+        return string.Equals(env, "CanKit.Adapter.SocketCAN", StringComparison.OrdinalIgnoreCase);
+    }
+
+    // Tracks outstanding rentals so ownership handoffs are directly observable.
+    // Only rentals routed through this instance count.
+    private sealed class CountingBufferAllocator : IBufferAllocator
+    {
+        private readonly ArrayPoolBufferAllocator _inner = new();
+        private int _outstanding;
+
+        public int Outstanding => Volatile.Read(ref _outstanding);
+
+        public IMemoryOwner<byte> Rent(int length, bool zeroFill = false)
+        {
+            Interlocked.Increment(ref _outstanding);
+            return new TrackedOwner(_inner.Rent(length, zeroFill), this);
+        }
+
+        public bool FrameNeedDispose => true;
+
+        private sealed class TrackedOwner(IMemoryOwner<byte> inner, CountingBufferAllocator owner) : IMemoryOwner<byte>
+        {
+            private int _disposed;
+
+            public Memory<byte> Memory => inner.Memory;
+
+            public void Dispose()
+            {
+                if (Interlocked.Exchange(ref _disposed, 1) == 0)
+                {
+                    inner.Dispose();
+                    Interlocked.Decrement(ref owner._outstanding);
+                }
+            }
+        }
+    }
+
+    private static ICanBus OpenClassic(string endpoint, IBufferAllocator busAllocator)
+        => CanBus.Open(endpoint, cfg => cfg
+            .SetProtocolMode(CanProtocolMode.Can20)
+            .Baud(500_000)
+            .BufferAllocator(busAllocator)
+            .SetAsyncBufferCapacity(64));
+
+    [Fact]
+    public void TransmitPeriodic_Does_Not_Keep_Reference_To_Caller_Buffer()
+    {
+        if (!ShouldRun()) return;
+
+        // The bus uses its own (default) allocator for BCM's private copy and for
+        // any RX rentals; we only track the caller's allocator, so the assertion
+        // measures pure caller-side ownership without RX noise polluting it.
+        var callerAllocator = new CountingBufferAllocator();
+        using var bus = OpenClassic(BcmOnlyEndpoint, new DefaultBufferAllocator());
+
+        IPeriodicTx? handle = null;
+        try
+        {
+            using (var callerOwner = callerAllocator.Rent(3))
+            {
+                new byte[] { 0xAA, 0xBB, 0xCC }.AsSpan().CopyTo(callerOwner.Memory.Span);
+
+                // ownMemory:false — the caller retains ownership and the frame's
+                // Dispose is a no-op; we're relying on the block's `using` for the
+                // owner to be the sole disposer.
+                using var callerFrame = CanFrame.Classic(0x321, callerOwner, ownMemory: false);
+                handle = bus.TransmitPeriodic(callerFrame, new PeriodicTxOptions(TimeSpan.FromMilliseconds(10), 2));
+
+                // Pre-fix behavior: `_frame = frame` would leave BCM referencing
+                // this same allocator's rental via `_frame._memoryOwner`. Post-fix,
+                // BCMPeriodicTx copies into a DIFFERENT allocator, so
+                // callerAllocator.Outstanding stays at 1.
+                callerAllocator.Outstanding.Should().Be(1,
+                    "TransmitPeriodic must not rent from the caller's allocator.");
+            } // callerOwner disposed here
+
+            // Sole rental is gone; BCM's private copy lives in the bus allocator.
+            callerAllocator.Outstanding.Should().Be(0,
+                "the caller must be able to dispose its owner without BCM leaking a reference.");
+        }
+        finally
+        {
+            handle?.Stop();
+        }
+
+        callerAllocator.Outstanding.Should().Be(0);
+    }
+
+    [Fact]
+    public void RemainingCount_Does_Not_Throw()
+    {
+        if (!ShouldRun()) return;
+
+        using var bus = OpenClassic(BcmOnlyEndpoint, new DefaultBufferAllocator());
+        using var frame = CanFrame.Classic(0x123, new byte[] { 1, 2, 3 });
+
+        using var handle = bus.TransmitPeriodic(frame, new PeriodicTxOptions(TimeSpan.FromMilliseconds(10), 2));
+
+        // Pre-fix: this would throw with EAGAIN from ThrowErrno("read(BCM TX_STATUS)")
+        // whenever the kernel hadn't yet enqueued a TX_STATUS reply on the non-blocking
+        // query socket. Post-fix: the read races the reply, on EAGAIN we poll+retry
+        // up to MaxAttempts, and on unrecoverable failure we fall back to the cached
+        // count instead of raising. Under Fake this exercises the happy path only.
+        Action act = () => _ = handle.RemainingCount;
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public async Task Update_And_Stop_Are_Safe_After_Caller_Disposes_Their_Frame()
+    {
+        if (!ShouldRun()) return;
+
+        var callerAllocator = new CountingBufferAllocator();
+        using var bus = OpenClassic(BcmOnlyEndpoint, new DefaultBufferAllocator());
+
+        IPeriodicTx? handle = null;
+        try
+        {
+            using (var owner = callerAllocator.Rent(4))
+            {
+                new byte[] { 0x11, 0x22, 0x33, 0x44 }.AsSpan().CopyTo(owner.Memory.Span);
+                using var caller = CanFrame.Classic(0x201, owner, ownMemory: false);
+                handle = bus.TransmitPeriodic(caller, new PeriodicTxOptions(TimeSpan.FromMilliseconds(5), 3));
+            } // caller frame + owner disposed here
+
+            callerAllocator.Outstanding.Should().Be(0,
+                "BCM must not hold a lease on the caller's rented buffer.");
+
+            // A subsequent Update() would previously reach through `_frame` back into
+            // the caller's now-disposed IMemoryOwner (Can20 path reads _frame.Data.Span
+            // in ToCanFrame()). With the fix, `_frame` refers to the duplicated owner
+            // rented at TransmitPeriodic time, so Update() is safe even though the
+            // caller's owner is gone.
+            Action updateWithoutFrame = () => handle!.Update(period: TimeSpan.FromMilliseconds(20));
+            updateWithoutFrame.Should().NotThrow();
+
+            Action queryRemaining = () => _ = handle!.RemainingCount;
+            queryRemaining.Should().NotThrow();
+
+            await Task.Delay(40);
+        }
+        finally
+        {
+            handle?.Stop();
+        }
+
+        callerAllocator.Outstanding.Should().Be(0);
+    }
+
+    [Fact]
+    public void Update_With_New_Frame_Releases_Previous_Bcm_Copy()
+    {
+        if (!ShouldRun()) return;
+
+        // BCM's private copies live in the bus allocator. To measure just the
+        // BCM lifecycle (and not RX rentals), we open a bus with a receive-side
+        // filter that drops everything, so no frames land in the RX pipe. The
+        // Fake libc still routes BCM emissions but filter-rejected deliveries
+        // are dropped without renting.
+        var busAllocator = new CountingBufferAllocator();
+        using var bus = CanBus.Open(BcmOnlyEndpoint, cfg => cfg
+            .SetProtocolMode(CanProtocolMode.Can20)
+            .Baud(500_000)
+            .BufferAllocator(busAllocator)
+            // Filter that never matches any of the frames used below (0x201, 0x202).
+            .AccMask(0x7FF, 0x7FF, CanFilterIDType.Standard)
+            .SetAsyncBufferCapacity(64));
+
+        using var first = CanFrame.Classic(0x201, new byte[] { 1, 2, 3 });
+        using var second = CanFrame.Classic(0x202, new byte[] { 9, 9, 9, 9, 9, 9 });
+
+        IPeriodicTx? handle = null;
+        try
+        {
+            handle = bus.TransmitPeriodic(first, new PeriodicTxOptions(TimeSpan.FromMilliseconds(20), 2));
+            var afterCtor = busAllocator.Outstanding;
+
+            handle.Update(frame: second);
+            var afterUpdate = busAllocator.Outstanding;
+
+            afterCtor.Should().BeGreaterOrEqualTo(1,
+                "the ctor's frame copy must have rented one buffer from the bus allocator.");
+            afterUpdate.Should().Be(afterCtor,
+                "Update must dispose the previous BCM copy before installing the new one; no net leak.");
+        }
+        finally
+        {
+            handle?.Stop();
+        }
+
+        busAllocator.Outstanding.Should().Be(0,
+            "Stop must dispose the current BCM copy so nothing outlives the periodic handle.");
+    }
+}

--- a/tests/CanKit.Tests/TestCases/SocketCanCapabilityTests.cs
+++ b/tests/CanKit.Tests/TestCases/SocketCanCapabilityTests.cs
@@ -1,0 +1,55 @@
+#if FAKE
+using System;
+using CanKit.Adapter.SocketCAN;
+using CanKit.Adapter.SocketCAN.Diagnostics;
+using FluentAssertions;
+using Xunit;
+
+namespace CanKit.Tests.TestCases;
+
+public class SocketCanCapabilityTests
+{
+    [Fact]
+    public void QueryCapabilities_Uses_Static_Features_When_Existing_Interface_Has_No_Ctrlmode()
+    {
+        var provider = new SocketCanProvider();
+        var options = new SocketCanBusOptions(provider)
+        {
+            ChannelName = "vcan3"
+        };
+
+        var capabilities = provider.QueryCapabilities(options);
+
+        capabilities.Features.Should().Be(provider.StaticFeatures);
+    }
+
+    [Fact]
+    public void QueryCapabilities_Throws_When_Interface_Does_Not_Exist()
+    {
+        var provider = new SocketCanProvider();
+        var options = new SocketCanBusOptions(provider)
+        {
+            ChannelName = "missing-can-interface"
+        };
+
+        Action query = () => provider.QueryCapabilities(options);
+
+        query.Should().Throw<SocketCanNativeException>();
+    }
+
+    [Fact]
+    public void QueryCapabilities_Throws_When_Existing_Interface_Has_A_Native_Error()
+    {
+        var provider = new SocketCanProvider();
+        var options = new SocketCanBusOptions(provider)
+        {
+            ChannelName = "vcan4"
+        };
+
+        Action query = () => provider.QueryCapabilities(options);
+
+        query.Should().Throw<SocketCanNativeException>()
+            .Which.NativeErrorCode.Should().Be(13U);
+    }
+}
+#endif


### PR DESCRIPTION
### Summary

Six focused bug fixes for the SocketCAN adapter's BCM periodic transmit (`BCMPeriodicTx`) and capability probing, ported from fixes we have been running in our fork. All changes are scoped to `CanKit.Adapter.SocketCAN` plus its test cases; no public API changes.

### Fixes

1. **Own the BCM periodic frame copy + harden `RemainingCount`** — the ctor stored the caller's `CanFrame` verbatim, so the BCM handle kept a reference to the caller's `IMemoryOwner` for the timer's lifetime (use-after-free via `_frame.Data.Span` once the caller disposed their owner); the handle now rents a private copy from the bus `IBufferAllocator`. `RemainingCount` no longer throws on EAGAIN: read-first, `poll(100 ms)` + retry, EINTR retry, cached last-known-count fallback.
2. **Free BCM handles when construction fails** — a ctor that throws never runs the caller's `Dispose`, leaking the duplicated frame and native fds; handle fields are pre-initialized and the ctor body is wrapped in try/finally. Also fixes the infinite-job `RemainingCount` encoding (kernel `count=0` ⇄ `IPeriodicTx` `-1`) and a stale cached count after `Update(repeatCount:)`.
3. **Cancel Fake BCM jobs on TX_DELETE/TX_SETUP** — the Fake backend ignored TX_DELETE, so `Stop()` left background emit loops running and polluted parallel matrix tests.
4. **Align BCM operations with the Linux kernel** — drops the separate query socket (a real kernel answers TX_READ for an unknown can_id with EINVAL; all socket access is serialized through a gate), carries `CAN_FD_FRAME` on TX_READ/TX_DELETE, and `Update()` always reprograms with nframes=1. This also fixes a copy-paste bug that made `Update(frame:)` throw `NotSupportedException` for CAN FD (unreachable FD branch). The Fake libc backend validates ops accordingly (EINVAL on malformed setup/unknown ops, TX_STATUS flags echo).
5. **Treat errno 0 as missing ctrlmode on open** — libsocketcan's `can_get_ctrlmode` returns -1 *without* setting errno when a (v)can link omits `IFLA_CAN_CTRLMODE`; netlink setup now skips config instead of throwing, matching `QueryCapabilities`.
6. **Tolerate unavailable ctrlmode when querying capabilities** — `QueryCapabilities` falls back to the static feature set when the interface exists and the failure is errno 0 (attribute missing) or EOPNOTSUPP; genuine native errors and non-existent interfaces still throw. The Fake backends model all three cases (vcan3: missing ctrlmode, vcan4: EACCES, unknown names).

### Notes for review

- Commit 1 ports a prerequisite that the later fixes build on (TX-lease frame copy + last-known-count machinery). Upstream `CanFrame` has no `Duplicate(IBufferAllocator)` API, so the owned copy is built by a **private static helper inside `BCMPeriodicTx`** using the existing public memory-owner factories — zero core API surface added. If you would rather have a public `CanFrame.Duplicate` core API instead, that is an easy follow-up.
- The `poll`/EAGAIN retry path of `RemainingCount` is only fully exercised on real Linux vcan; under `-c Fake` the in-memory backend answers synchronously (noted in the test file's doc comment).

### Tests

- New/extended coverage: `SocketCanBcmOwnershipTests` (TX-lease copy, RemainingCount no-throw contract incl. infinite encoding, Update/Stop lifecycle, FD case) and `SocketCanCapabilityTests` (ctrlmode fallback + both throwing paths).
- Hardware-free verification on macOS: `dotnet build CanKitAdapters.slnf -c Release` and `-c Fake` clean; `CANKIT_TEST_ADAPTERS=CanKit.Adapter.Virtual dotnet test CanKitAdapters.slnf -c Release -f net8.0` → 79 passed; `CANKIT_TEST_ADAPTERS=CanKit.Adapter.SocketCAN dotnet test CanKitAdapters.slnf -c Fake -f net8.0` → 82 passed (Fake backend is fully in-memory, so the SocketCAN matrix genuinely runs without Linux).
