### PR TITLE
fix(zlg,controlcan): plug auto-send index leak and fake infinite receive timeout

### DIFF
--- a/src/adapters/CanKit.Adapter.ControlCAN/Utils/ControlCanPeriodicTx.cs
+++ b/src/adapters/CanKit.Adapter.ControlCAN/Utils/ControlCanPeriodicTx.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using CanKit.Abstractions.API.Can;
 using CanKit.Abstractions.API.Can.Definitions;
 using CanKit.Abstractions.API.Common;
@@ -42,21 +42,30 @@ public sealed class ControlCanPeriodicTx : IPeriodicTx
         _retry = bus.Options.TxRetryPolicy == TxRetryPolicy.AlwaysRetry;
         // Unique index (best effort, ushort range)
         _index = (ushort)bus.GetAutoSendIndex();
-
-        // Fire once immediately if requested
-        if (options.FireImmediately)
+        try
         {
-            try
+            // Fire once immediately if requested
+            if (options.FireImmediately)
             {
-                _ = _bus.Transmit(frame);
+                try
+                {
+                    _ = _bus.Transmit(frame);
+                }
+                catch
+                {
+                }
             }
-            catch
-            {
-            }
-        }
 
-        // Program device auto transmit; repeat is managed by software monitor if finite
-        ApplyHardware(true, _frame, Period);
+            // Program device auto transmit; repeat is managed by software monitor if finite
+            ApplyHardware(true, _frame, Period);
+        }
+        catch
+        {
+            // A constructor that throws is never Disposed by the caller: return the
+            // auto-send slot already taken so failed attempts cannot exhaust the pool.
+            try { _bus.FreeAutoSendIndex(_index); } catch { /* ignored */ }
+            throw;
+        }
     }
 
 

--- a/src/adapters/CanKit.Adapter.ZLG/Native/ZLGAPI.Fake.cs
+++ b/src/adapters/CanKit.Adapter.ZLG/Native/ZLGAPI.Fake.cs
@@ -459,7 +459,9 @@ public static class ZLGCAN
         DequeueQueue();
         while (count < len)
         {
-            var remaining = wait_time + start - Environment.TickCount;
+            var remaining = wait_time == -1
+                ? -1
+                : wait_time + start - Environment.TickCount;
             if (remaining <= 0 && wait_time != -1) break;
             ch.RxEvtClassic.WaitOne(TimeSpan.FromMilliseconds(Math.Min(remaining, 10)));
             DequeueQueue();
@@ -486,7 +488,9 @@ public static class ZLGCAN
         DequeueQueue();
         while (count < len)
         {
-            var remaining = wait_time + start - Environment.TickCount;
+            var remaining = wait_time == -1
+                ? -1
+                : wait_time + start - Environment.TickCount;
             if (remaining <= 0 && wait_time != -1) break;
             ch.RxEvtFd.WaitOne(TimeSpan.FromMilliseconds(Math.Min(remaining, 10)));
             DequeueQueue();
@@ -515,7 +519,9 @@ public static class ZLGCAN
         DequeueQueue();
         while (count < len)
         {
-            var remaining = wait_time + start - Environment.TickCount;
+            var remaining = wait_time == -1
+                ? -1
+                : wait_time + start - Environment.TickCount;
             if (remaining <= 0 && wait_time != -1) break;
             dev.MergeRxEvt.WaitOne(TimeSpan.FromMilliseconds(Math.Min(remaining, 10)));
             DequeueQueue();

--- a/src/adapters/CanKit.Adapter.ZLG/Utils/ZlgPeriodicTx.cs
+++ b/src/adapters/CanKit.Adapter.ZLG/Utils/ZlgPeriodicTx.cs
@@ -45,19 +45,28 @@ public sealed class ZlgPeriodicTx : IPeriodicTx
 
         // Unique index (best effort, ushort range)
         _index = (ushort)bus.GetAutoSendIndex();
-
-        // Fire once immediately if requested
-        if (options.FireImmediately)
+        try
         {
-            try
+            // Fire once immediately if requested
+            if (options.FireImmediately)
             {
-                _ = _bus.Transmit(new[] { frame }.AsSpan(), 0);
+                try
+                {
+                    _ = _bus.Transmit(new[] { frame }.AsSpan(), 0);
+                }
+                catch { }
             }
-            catch { }
-        }
 
-        // Program device auto transmit; repeat is managed by software monitor if finite
-        ApplyHardware(true, _frame, Period);
+            // Program device auto transmit; repeat is managed by software monitor if finite
+            ApplyHardware(true, _frame, Period);
+        }
+        catch
+        {
+            // A constructor that throws is never Disposed by the caller: return the
+            // auto-send slot already taken so failed attempts cannot exhaust the pool.
+            try { _bus.FreeAutoSendIndex(_index); } catch { /* ignored */ }
+            throw;
+        }
     }
 
     public TimeSpan Period { get; private set; }

--- a/tests/CanKit.Tests/CanKit.Tests.csproj
+++ b/tests/CanKit.Tests/CanKit.Tests.csproj
@@ -5,6 +5,8 @@
     <RootNamespace>CanKit.Tests</RootNamespace>
     <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks Condition="'$(Configuration)' == 'Fake'">true</AllowUnsafeBlocks>
+    <DefineConstants Condition="'$(Configuration)' == 'Fake'">$(DefineConstants);FAKE</DefineConstants>
     <TargetFrameworks>net8.0;net48</TargetFrameworks>
     <Configurations>Debug;Release;Fake</Configurations>
     <Platforms>AnyCPU;X86;X64</Platforms>

--- a/tests/CanKit.Tests/TestCases/ZlgFakeNativeReceiveTests.cs
+++ b/tests/CanKit.Tests/TestCases/ZlgFakeNativeReceiveTests.cs
@@ -1,0 +1,160 @@
+#if FAKE
+using System;
+using System.Threading.Tasks;
+using CanKit.Adapter.ZLG.Definitions;
+using CanKit.Adapter.ZLG.Native;
+using FluentAssertions;
+using Xunit;
+
+namespace CanKit.Tests.TestCases;
+
+public class ZlgFakeNativeReceiveTests
+{
+    [Theory]
+    [InlineData(NativeReceiveKind.Classic)]
+    [InlineData(NativeReceiveKind.Fd)]
+    [InlineData(NativeReceiveKind.Merged)]
+    public async Task Receive_InfiniteWait_PreservesSentinelAcrossPartialBatch(
+        NativeReceiveKind receiveKind)
+    {
+        var devicePointer = ZLGCAN.ZCAN_OpenDevice(
+            ZLGCAN.ZCAN_USBCANFD_200U,
+            uint.MaxValue,
+            0);
+        using var device = new ZlgDeviceHandle(devicePointer);
+
+        var config = new ZLGCAN.ZCAN_CHANNEL_INIT_CONFIG
+        {
+            can_type = receiveKind == NativeReceiveKind.Classic ? 0U : 1U,
+            config =
+            {
+                can =
+                {
+                    acc_mask = uint.MaxValue
+                }
+            }
+        };
+
+        using var rx = ZLGCAN.ZCAN_InitCAN(device, 0, ref config);
+        rx.SetDevice(devicePointer);
+        ConfigureBitrate(device, 0, receiveKind);
+        ZLGCAN.ZCAN_SetValue(device, "0/work_mode", "2").Should().Be(1);
+        ZLGCAN.ZCAN_StartCAN(rx).Should().Be(1);
+
+        var receiveStarted = new TaskCompletionSource<object?>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var receiveTask = StartReceive(
+            receiveKind,
+            device,
+            rx,
+            receiveStarted);
+
+        await receiveStarted.Task;
+        await Task.Delay(50);
+        Transmit(rx, receiveKind, 0x101);
+        await Task.Delay(50);
+        Transmit(rx, receiveKind, 0x102);
+
+        var completed = await Task.WhenAny(receiveTask, Task.Delay(TimeSpan.FromSeconds(2)));
+        completed.Should().Be(receiveTask, "the infinite-wait receive should finish once the batch arrives");
+        var received = await receiveTask;
+        received.Should().Be(2);
+    }
+
+    private static Task<uint> StartReceive(
+        NativeReceiveKind receiveKind,
+        ZlgDeviceHandle device,
+        ZlgChannelHandle channel,
+        TaskCompletionSource<object?> receiveStarted)
+        => Task.Run(() =>
+        {
+            receiveStarted.SetResult(null);
+            return receiveKind switch
+            {
+                NativeReceiveKind.Classic => ZLGCAN.ZCAN_Receive(
+                    channel,
+                    new ZLGCAN.ZCAN_Receive_Data[2],
+                    2,
+                    -1),
+                NativeReceiveKind.Fd => ZLGCAN.ZCAN_ReceiveFD(
+                    channel,
+                    new ZLGCAN.ZCAN_ReceiveFD_Data[2],
+                    2,
+                    -1),
+                NativeReceiveKind.Merged => ZLGCAN.ZCAN_ReceiveData(
+                    device,
+                    new ZLGCAN.ZCANDataObj[2],
+                    2,
+                    -1),
+                _ => throw new ArgumentOutOfRangeException(nameof(receiveKind))
+            };
+        });
+
+    private static void Transmit(
+        ZlgChannelHandle channel,
+        NativeReceiveKind receiveKind,
+        uint id)
+    {
+        if (receiveKind == NativeReceiveKind.Classic)
+        {
+            TransmitClassic(channel, id);
+            return;
+        }
+
+        TransmitFd(channel, id);
+    }
+
+    private static unsafe void TransmitClassic(ZlgChannelHandle channel, uint id)
+    {
+        var frame = new ZLGCAN.ZCAN_Transmit_Data
+        {
+            frame = new ZLGCAN.can_frame
+            {
+                can_id = id,
+                can_dlc = 0
+            }
+        };
+
+        ZLGCAN.ZCAN_Transmit(channel, &frame, 1).Should().Be(1);
+    }
+
+    private static unsafe void TransmitFd(ZlgChannelHandle channel, uint id)
+    {
+        var frame = new ZLGCAN.ZCAN_TransmitFD_Data
+        {
+            frame = new ZLGCAN.canfd_frame
+            {
+                can_id = id,
+                len = 0
+            }
+        };
+
+        ZLGCAN.ZCAN_TransmitFD(channel, &frame, 1).Should().Be(1);
+    }
+
+    private static void ConfigureBitrate(
+        ZlgDeviceHandle device,
+        int channel,
+        NativeReceiveKind receiveKind)
+    {
+        if (receiveKind == NativeReceiveKind.Classic)
+        {
+            ZLGCAN.ZCAN_SetValue(device, $"{channel}/baud_rate", "500000")
+                .Should().Be(1);
+            return;
+        }
+
+        ZLGCAN.ZCAN_SetValue(device, $"{channel}/canfd_abit_baud_rate", "500000")
+            .Should().Be(1);
+        ZLGCAN.ZCAN_SetValue(device, $"{channel}/canfd_dbit_baud_rate", "2000000")
+            .Should().Be(1);
+    }
+
+    public enum NativeReceiveKind
+    {
+        Classic,
+        Fd,
+        Merged
+    }
+}
+#endif


### PR DESCRIPTION
### Summary

Three small bug fixes for the ZLG and ControlCAN adapters (plus fake-native test coverage), ported from fixes we have been running in our fork. No public API changes.

### Fixes

1. **fix(controlcan): free auto-send index when periodic TX construction fails** — `ControlCanPeriodicTx`'s constructor acquires an auto-send slot via `GetAutoSendIndex`, but if `ApplyHardware` throws afterwards, the slot is never returned: a throwing constructor is never `Dispose`d by the caller, so repeated failed `TransmitPeriodic` attempts can exhaust the index pool. The post-`GetAutoSendIndex` section is now wrapped so the slot is freed on failure.
2. **fix(zlg): free auto-send index when periodic TX construction fails** — identical defect and fix shape in `ZlgPeriodicTx`.
3. **fix(zlg): preserve infinite fake receive timeout** — in the fake ZLG backend, `ZCAN_Receive`/`ZCAN_ReceiveFD`/`ZCAN_ReceiveData` computed the remaining wait as `wait_time + start - TickCount` even when `wait_time` was -1 (infinite); the remaining value drifted below -1 and `WaitOne(TimeSpan)` threw `ArgumentOutOfRangeException` instead of blocking until frames arrived. The -1 sentinel is now preserved so infinite waits poll in 10 ms slices.

### Notes for review

- The two periodic-TX fixes are deliberately narrower than the versions in our fork: upstream's constructors never duplicated the TX frame, so there was no frame-release path to port — only the slot leak.
- The test project's csproj now defines `FAKE` (and `AllowUnsafeBlocks`) for the `Fake` configuration so the new `#if FAKE` fake-native tests actually compile — upstream's test project does not inherit `src/Directory.Build.props`. Two lines; easy to relocate into a shared props file if you prefer.
- New `ZlgFakeNativeReceiveTests` (3 tests: classic, FD, merged receive with infinite timeout across a partial batch) were verified to genuinely guard the fix: reverting `ZLGAPI.Fake.cs` to the pre-fix state makes all three fail with the exact `ArgumentOutOfRangeException`.

### Tests (hardware-free, macOS)

- `dotnet build CanKitAdapters.slnf -c Release` and `-c Fake` — clean.
- `CANKIT_TEST_ADAPTERS=CanKit.Adapter.Virtual dotnet test CanKitAdapters.slnf -c Release -f net8.0` — 72 passed.
- `CANKIT_TEST_ADAPTERS=CanKit.Adapter.ZLG dotnet test CanKitAdapters.slnf -c Fake -f net8.0` — 145 passed.
- `CANKIT_TEST_ADAPTERS=CanKit.Adapter.ControlCAN dotnet test CanKitAdapters.slnf -c Fake -f net8.0` — 65 passed.
