### PR TITLE
fix(core): synchronize CanRegistry against concurrent access

### DIFF
--- a/src/core/CanKit.Core/CanKit.Core.csproj
+++ b/src/core/CanKit.Core/CanKit.Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
 	<Platforms>AnyCPU</Platforms>
@@ -40,5 +40,10 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="" />
+  </ItemGroup>
+  <!-- Lets the xUnit suite drive the internal Register* surface for the registry
+       concurrency stress tests (CanRegistryConcurrencyTests). -->
+  <ItemGroup>
+    <InternalsVisibleTo Include="CanKit.Tests" />
   </ItemGroup>
 </Project>

--- a/src/core/CanKit.Core/Registry/CanRegistry.cs
+++ b/src/core/CanKit.Core/Registry/CanRegistry.cs
@@ -34,8 +34,11 @@ public partial class CanRegistry
     /// <returns>The resolved CAN model provider. (解析到的CAN模型提供者)</returns>
     public ICanModelProvider Resolve(DeviceType deviceType)
     {
-        if (_providers.TryGetValue(deviceType, out var provider))
-            return provider;
+        lock (_sync)
+        {
+            if (_providers.TryGetValue(deviceType, out var provider))
+                return provider;
+        }
 
         var ex = new NotSupportedException(
             $"Unknown device. DeviceType='{deviceType}");
@@ -57,10 +60,14 @@ public partial class CanRegistry
         if (string.IsNullOrWhiteSpace(factoryId))
             throw new ArgumentException($"FactoryId is null or empty.", nameof(factoryId));
 
-        if (_factories.TryGetValue(factoryId, out var factory))
-            return factory;
+        string known;
+        lock (_sync)
+        {
+            if (_factories.TryGetValue(factoryId, out var factory))
+                return factory;
 
-        var known = _factories.Count == 0 ? "<none>" : string.Join(", ", _factories.Keys);
+            known = _factories.Count == 0 ? "<none>" : string.Join(", ", _factories.Keys);
+        }
         var ex = new NotSupportedException(
             $"Unknown factory. FactoryId='{factoryId}'. Known=[{known}]");
 
@@ -77,13 +84,18 @@ public partial class CanRegistry
     public bool TryOpenEndPoint(string endpoint, Action<IBusInitOptionsConfigurator>? configure, out ICanBus? bus)
     {
         var ep = CanEndpoint.Parse(endpoint);
-        if (_handlers.TryGetValue(ep.Scheme, out var h))
+        Func<CanEndpoint, Action<IBusInitOptionsConfigurator>?, ICanBus>? h;
+        lock (_sync)
         {
-            bus = h(ep, configure);
-            return true;
+            if (!_handlers.TryGetValue(ep.Scheme, out h))
+            {
+                bus = null;
+                return false;
+            }
         }
-        bus = null;
-        return false;
+        // Invoke outside the lock: opening a bus may be slow and must not block readers.
+        bus = h(ep, configure);
+        return true;
     }
 
     /// <summary>
@@ -93,13 +105,17 @@ public partial class CanRegistry
     public bool TryPrepareEndPoint(string endpoint, Action<IBusInitOptionsConfigurator>? configure, out PreparedBusContext? prepared)
     {
         var ep = CanEndpoint.Parse(endpoint);
-        if (_prepareHandlers.TryGetValue(ep.Scheme, out var p))
+        Func<CanEndpoint, Action<IBusInitOptionsConfigurator>?, PreparedBusContext>? p;
+        lock (_sync)
         {
-            prepared = p(ep, configure);
-            return true;
+            if (!_prepareHandlers.TryGetValue(ep.Scheme, out p))
+            {
+                prepared = null;
+                return false;
+            }
         }
-        prepared = null;
-        return false;
+        prepared = p(ep, configure);
+        return true;
     }
 
     /// <summary>
@@ -109,13 +125,16 @@ public partial class CanRegistry
     /// <exception cref="InvalidOperationException">Thrown when a provider with the same DeviceType is already registered.(设备类型已存在时抛出)</exception>
     internal void RegisterProvider(params ICanModelProvider[] providers)
     {
-        foreach (var provider in providers)
+        lock (_sync)
         {
-            if (_providers.ContainsKey(provider.DeviceType))
+            foreach (var provider in providers)
             {
-                throw new InvalidOperationException($"A provider with the DeviceType '{provider.DeviceType}' is already registered.");
+                if (_providers.ContainsKey(provider.DeviceType))
+                {
+                    throw new InvalidOperationException($"A provider with the DeviceType '{provider.DeviceType}' is already registered.");
+                }
+                _providers.Add(provider.DeviceType, provider);
             }
-            _providers.Add(provider.DeviceType, provider);
         }
     }
 
@@ -128,11 +147,14 @@ public partial class CanRegistry
     /// <exception cref="InvalidOperationException">Thrown when a factory with the same ID is already registered.(工厂ID已存在时抛出)</exception>
     internal void RegisterFactory(string factoryId, ICanFactory factory)
     {
-        if (_factories.ContainsKey(factoryId))
+        lock (_sync)
         {
-            throw new InvalidOperationException($"A factory with the ID '{factoryId}' is already registered.");
+            if (_factories.ContainsKey(factoryId))
+            {
+                throw new InvalidOperationException($"A factory with the ID '{factoryId}' is already registered.");
+            }
+            _factories.Add(factoryId, factory);
         }
-        _factories.Add(factoryId, factory);
     }
 
     /// <summary>
@@ -143,19 +165,20 @@ public partial class CanRegistry
         if (e is null) throw new ArgumentNullException(nameof(e));
         if (string.IsNullOrWhiteSpace(e.Scheme)) throw new ArgumentNullException(nameof(e.Scheme));
 
-        _handlers[e.Scheme] = e.Open;
-        _prepareHandlers[e.Scheme] = e.Prepare;
-
-        if (e.Enumerate != null)
-            _enumerators[e.Scheme] = e.Enumerate;
-
-        foreach (var alias in e.Alias.Append(e.Scheme))
+        lock (_sync)
         {
-            if (!_enumeratorAlias.ContainsKey(alias))
-                _enumeratorAlias[alias] = e.Scheme;
+            _handlers[e.Scheme] = e.Open;
+            _prepareHandlers[e.Scheme] = e.Prepare;
+
+            if (e.Enumerate != null)
+                _enumerators[e.Scheme] = e.Enumerate;
+
+            foreach (var alias in e.Alias.Append(e.Scheme))
+            {
+                if (!_enumeratorAlias.ContainsKey(alias))
+                    _enumeratorAlias[alias] = e.Scheme;
+            }
         }
-
-
     }
 }
 
@@ -167,6 +190,11 @@ public partial class CanRegistry
 
     // factory
     private readonly Dictionary<string, ICanFactory> _factories = new();
+
+    // Every dictionary in this class is guarded by this lock. Registration happens mostly
+    // during startup, but the public read surface (Resolve/Factory/TryOpen*/Enumerate) is
+    // reachable from arbitrary threads concurrently with any late (re-)registration.
+    private readonly object _sync = new();
 
     // endpoint
     private readonly Dictionary<string, Func<IEnumerable<BusEndpointInfo>>> _enumerators =
@@ -254,12 +282,22 @@ public partial class CanRegistry
     /// </summary>
     public IEnumerable<BusEndpointInfo> EnumerateEndPoints(IEnumerable<string>? vendorsOrSchemes)
     {
+        // Snapshot under the lock: an iterator cannot yield inside a lock block, and a live
+        // dictionary must not be enumerated while a concurrent registration mutates it.
+        KeyValuePair<string, Func<IEnumerable<BusEndpointInfo>>>[] enumerators;
+        Dictionary<string, string> alias;
+        lock (_sync)
+        {
+            enumerators = _enumerators.ToArray();
+            alias = new Dictionary<string, string>(_enumeratorAlias, StringComparer.OrdinalIgnoreCase);
+        }
+
         if (vendorsOrSchemes is null)
         {
-            foreach (var e in _enumerators.Values)
+            foreach (var e in enumerators)
             {
                 IEnumerable<BusEndpointInfo> items;
-                try { items = e() ?? []; }
+                try { items = e.Value() ?? []; }
                 catch { items = []; }
                 foreach (var it in items) yield return it;
             }
@@ -267,12 +305,12 @@ public partial class CanRegistry
         }
         var schemes = vendorsOrSchemes.Select(i =>
         {
-            if (_enumeratorAlias.TryGetValue(i, out var aliased))
+            if (alias.TryGetValue(i, out var aliased))
                 return aliased;
             return i;
         });
         var set = new HashSet<string>(schemes, StringComparer.OrdinalIgnoreCase);
-        foreach (var kv in _enumerators)
+        foreach (var kv in enumerators)
         {
             if (!set.Contains(kv.Key)) continue;
             IEnumerable<BusEndpointInfo> items;

--- a/tests/CanKit.Tests/TestCases/CanRegistryConcurrencyTests.cs
+++ b/tests/CanKit.Tests/TestCases/CanRegistryConcurrencyTests.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using CanKit.Abstractions.API.Common.Definitions;
+using CanKit.Abstractions.SPI.Registry.Core.Endpoints;
+using CanKit.Core.Registry;
+using FluentAssertions;
+using Xunit;
+
+namespace CanKit.Tests.TestCases;
+
+/// <summary>
+/// Concurrency stress for <see cref="CanRegistry"/>: parallel RegisterEndPoint churn plus
+/// concurrent readers (TryOpenEndPoint / EnumerateEndPoints) on the shared singleton must
+/// not corrupt state or throw from racing dictionary enumeration.
+/// </summary>
+public class CanRegistryConcurrencyTests : IClassFixture<TestCaseProvider>
+{
+    // The internal Register* methods are reachable directly because CanKit.Core exposes
+    // InternalsVisibleTo to this test assembly. The singleton (not a private instance) is
+    // used deliberately, since the internal ctor mutates CanRegistry.Instance and would race
+    // the lazy singleton build of other tests running in parallel.
+    [Fact]
+    public async Task CanRegistry_Parallel_Registration_And_Readers_Do_Not_Race()
+    {
+        var registry = CanRegistry.Registry;
+        const int schemeCount = 16;
+        var schemes = Enumerable.Range(0, schemeCount).Select(i => $"stress-{i}").ToArray();
+        var exceptions = new ConcurrentQueue<Exception>();
+
+        var stop = new ManualResetEventSlim();
+        var readers = Enumerable.Range(0, 4).Select(_unused => Task.Run(() =>
+        {
+            try
+            {
+                while (!stop.IsSet)
+                {
+                    _ = registry.TryOpenEndPoint("stress-7://x", null, out _);
+                    _ = registry.EnumerateEndPoints(null).Count();
+                    _ = registry.EnumerateEndPoints(new[] { "stress-3" }).Count();
+                }
+            }
+            catch (Exception ex) { exceptions.Enqueue(ex); }
+        })).ToArray();
+
+        var writers = schemes.Select(scheme => Task.Run(() =>
+        {
+            try
+            {
+                registry.RegisterEndPoint(new RawEndpointRegistration(
+                    scheme,
+                    open: (ep, cfg) => null!,   // never invoked by this test's readers' assertion
+                    prepare: (ep, cfg) => null!)
+                {
+                    Enumerate = () => Array.Empty<BusEndpointInfo>(),
+                });
+            }
+            catch (Exception ex) { exceptions.Enqueue(ex); }
+        })).ToArray();
+
+        try
+        {
+            await Task.WhenAll(writers);
+            stop.Set();
+            await Task.WhenAll(readers);
+        }
+        finally
+        {
+            // Remove the stress schemes under the registry's private lock so no residue is
+            // visible to other tests sharing the singleton (and no unlocked mutation races
+            // a concurrent snapshotting reader).
+            WithRegistryLock(registry, () =>
+            {
+                foreach (var scheme in schemes)
+                {
+                    RemoveFromRegistryDictionaries(registry, scheme);
+                }
+            });
+        }
+
+        exceptions.Should().BeEmpty("parallel registration and reads must be race-free");
+
+        // Spot-check consistency: re-register one scheme and resolve it through the public API.
+        var probe = "stress-probe";
+        try
+        {
+            registry.RegisterEndPoint(new RawEndpointRegistration(
+                probe, open: (ep, cfg) => null!, prepare: (ep, cfg) => null!));
+            registry.TryOpenEndPoint($"{probe}://x", null, out _).Should().BeTrue(
+                "a scheme registered under concurrency must remain resolvable afterwards");
+        }
+        finally
+        {
+            WithRegistryLock(registry, () => RemoveFromRegistryDictionaries(registry, probe));
+        }
+    }
+
+    private static void WithRegistryLock(CanRegistry registry, Action action)
+    {
+        var syncField = typeof(CanRegistry).GetField("_sync", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("CanRegistry._sync field not found.");
+        lock (syncField.GetValue(registry)!)
+        {
+            action();
+        }
+    }
+
+    private static void RemoveFromRegistryDictionaries(CanRegistry registry, string scheme)
+    {
+        var type = typeof(CanRegistry);
+        foreach (var fieldName in new[] { "_handlers", "_prepareHandlers", "_enumerators", "_enumeratorAlias" })
+        {
+            var field = type.GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)
+                ?? throw new InvalidOperationException($"CanRegistry.{fieldName} field not found.");
+            ((IDictionary)field.GetValue(registry)!).Remove(scheme);
+        }
+    }
+}


### PR DESCRIPTION
### Summary

`CanRegistry`'s dictionaries were plain, unsynchronized maps: any late (re-)registration racing the public read surface (`Resolve`/`Factory`/`TryOpenEndPoint`/`EnumerateEndPoints`) could corrupt state or throw from concurrent enumeration. This is a realistic scenario for applications that register endpoints/providers after startup (plugin-style hosts, adapter assemblies finishing their preload registration while a bus is already being opened).

### Fix

- All registry accesses now take one private lock.
- Readers that iterate (`Factory`'s known-list, `EnumerateEndPoints`) snapshot under the lock and enumerate outside of it.
- Endpoint handlers are invoked **outside** the lock, so a slow `Open` never blocks other readers (and a handler that itself touches the registry cannot deadlock).

No public API changes. Ported from a fix we have been running in our fork.

### Tests

- New `CanRegistryConcurrencyTests`: parallel `RegisterEndPoint` churn (16 schemes) plus 4 concurrent readers spinning on `TryOpenEndPoint`/`EnumerateEndPoints` against the shared singleton. `CanKit.Core` now exposes `InternalsVisibleTo` to the test assembly so the test can drive the internal `Register*` surface.
- Non-vacuity check: with the registry reverted to the unsynchronized version, the new test fails consistently (concurrent-enumeration exception); with the fix it passes 5/5 filtered runs (~59 ms each, no flakiness).
- `dotnet build CanKitAdapters.slnf -c Release` / `-c Fake` clean; `CANKIT_TEST_ADAPTERS=CanKit.Adapter.Virtual dotnet test CanKitAdapters.slnf -c Release -f net8.0` → 73 passed, 0 failed (72 baseline + 1 new).

### Note

The test cleans up its stress registrations from the shared singleton via reflection over the registry's private field names — a rename of those fields would break the test with a clear error message.
