### PR TITLE
test: stabilize one-shot batch tests against RX frame loss

### DIFF
--- a/tests/CanKit.Tests/TestCases/TransceiverTests.cs
+++ b/tests/CanKit.Tests/TestCases/TransceiverTests.cs
@@ -33,9 +33,12 @@ public class ThroughputAndFeaturesTests : IClassFixture<TestCaseProvider>
             var frames = TestHelpers.GenerateSeqFrames(ring, batchSize).ToArray();
             var v = new TestHelpers.SequenceVerifier();
 
-            await TestHelpers.SendBurstAsync(tx, frames, gapMs: 0);
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
-            var rec = await TestHelpers.ReceiveUntilAsync(rx, v, batchSize, 2000, cts.Token);
+            var recTask = TestHelpers.ReceiveUntilAsync(rx, v, batchSize, 2000, cts.Token);
+            await TestHelpers.SendBurstAsync(tx, frames, gapMs: 0);
+            int rec;
+            try { rec = await recTask; }
+            catch (OperationCanceledException) { rec = v.Received; }
             rec.Should().Be(batchSize);
             v.Lost.Should().Be(0);
             v.BadData.Should().Be(0);
@@ -59,9 +62,12 @@ public class ThroughputAndFeaturesTests : IClassFixture<TestCaseProvider>
             var frames = TestHelpers.GenerateSeqFrames(ring, batchSize).ToArray();
             var v = new TestHelpers.SequenceVerifier();
 
-            await TestHelpers.SendBurstAsync(tx, frames, gapMs: 0);
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
-            var rec = await TestHelpers.ReceiveUntilAsync(rx, v, batchSize, 2000, cts.Token);
+            var recTask = TestHelpers.ReceiveUntilAsync(rx, v, batchSize, 2000, cts.Token);
+            await TestHelpers.SendBurstAsync(tx, frames, gapMs: 0);
+            int rec;
+            try { rec = await recTask; }
+            catch (OperationCanceledException) { rec = v.Received; }
 
             rec.Should().Be(batchSize);
             v.Lost.Should().Be(0);

--- a/tests/CanKit.Tests/Utils/TestHelpers.cs
+++ b/tests/CanKit.Tests/Utils/TestHelpers.cs
@@ -119,7 +119,7 @@ internal static class TestHelpers
     public static async Task<int> ReceiveUntilAsync(ICanBus bus, SequenceVerifier v, int expected, int timeoutMs, CancellationToken token)
     {
         var result = 0;
-        var sw = new Stopwatch();
+        var sw = Stopwatch.StartNew();
         while (!token.IsCancellationRequested && v.Received < expected && sw.ElapsedMilliseconds < timeoutMs)
         {
 


### PR DESCRIPTION
## Summary

Refs #23 — fixes the two uncontroversial findings from the analysis of the flaky ZLG hardware tests ([failing CI run](https://github.com/pkuyo/CanKit/actions/runs/31075795417/job/92533436386)):

1. **One-shot tests now receive concurrently with the burst.** Previously `OneShot_Batch_Classic_64_And_128` and `OneShot_Batch_FD_64_And_128` sent the full 64/128-frame burst with `gapMs: 0` and only started receiving afterwards, so frame survival depended entirely on device/driver buffering before the first `ReceiveAsync` call. The receiver loop now starts before the burst, mirroring the pattern already used by the continuous tests. If frames are still lost, the test still fails with the same assertions (no tolerance added).

2. **`ReceiveUntilAsync`: start the Stopwatch.** `sw` was never started, so `sw.ElapsedMilliseconds` was always 0 and the `timeoutMs` parameter was dead code.

## Not in scope (see #23)

- The "half + 1" loss pattern (33/64, 65/128) root cause — needs ZLG hardware access.
- The `Frame_Types_And_Lengths_Are_Transferred` "0 of 6" failure — likely channel start latency; a settle/sync mechanism should be discussed separately.

## Testing

- `dotnet build` of the test project succeeds (net48 + net8.0, 0 errors).
- Hardware tests could not be run locally (macOS dev machine, no ZLG adapter; `CANKIT_TEST_ADAPTERS` requires a hardware/virtual adapter assembly) — validation has to happen in CI.