### PR TITLE
feat(build): add .NET 10 support and modernize the toolchain

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -37,7 +37,7 @@ body:
     id: dotnet
     attributes:
       label: .NET SDK/runtime
-      placeholder: "SDK 8.0.x"
+      placeholder: "SDK 10.0.x / 8.0.x"
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/compat_test_report.yml
+++ b/.github/ISSUE_TEMPLATE/compat_test_report.yml
@@ -23,7 +23,7 @@ body:
     id: dotnet
     attributes:
       label: .NET SDK/runtime
-      placeholder: "SDK 8.0.x"
+      placeholder: "SDK 10.0.x / 8.0.x"
     validations:
       required: true
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: nuget
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    ignore:
+      # FluentAssertions v8+ moved to a commercial license (Xceed) for commercial use.
+      - dependency-name: FluentAssertions
+        versions: [">= 8.0.0"]
+      # Stay on xunit v2; a move to xunit v3 is a separate discussion.
+      - dependency-name: xunit
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/controlcan-ci.yml
+++ b/.github/workflows/controlcan-ci.yml
@@ -6,11 +6,15 @@ on:
       - 'src/core/CanKit.Core/**'
       - 'src/adapters/CanKit.Adapter.ControlCAN/**'
       - 'tests/CanKit.Tests/**'
+      - 'src/Directory.Build.props'
+      - 'global.json'
   pull_request:
     paths:
       - 'src/core/CanKit.Core/**'
       - 'src/adapters/CanKit.Adapter.ControlCAN/**'
       - 'tests/CanKit.Tests/**'
+      - 'src/Directory.Build.props'
+      - 'global.json'
 jobs:
   windows:
     name: ControlCAN (windows) – ${{ matrix.tfm }}
@@ -18,18 +22,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tfm: [net8.0, net48]
+        tfm: [net8.0, net10.0, net48]
     env:
       DOTNET_NOLOGO: true
       DOTNET_CLI_TELEMETRY_OPTOUT: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: |
+            8.0.x
+            10.0.x
+          global-json-file: global.json
 
       - name: Configure endpoints
         shell: pwsh
@@ -44,7 +51,7 @@ jobs:
 
       - name: Upload Test Results (${{ matrix.tfm }})
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-windows-${{ matrix.tfm }}
           path: '**/TestResults-${{ matrix.tfm }}.trx'

--- a/.github/workflows/kvaser-ci.yml
+++ b/.github/workflows/kvaser-ci.yml
@@ -6,11 +6,15 @@ on:
       - 'src/core/CanKit.Core/**'
       - 'src/adapters/CanKit.Adapter.Kvaser/**'
       - 'tests/CanKit.Tests/**'
+      - 'src/Directory.Build.props'
+      - 'global.json'
   pull_request:
     paths:
       - 'src/core/CanKit.Core/**'
       - 'src/adapters/CanKit.Adapter.Kvaser/**'
       - 'tests/CanKit.Tests/**'
+      - 'src/Directory.Build.props'
+      - 'global.json'
 jobs:
   windows:
     name: Kvaser (windows) – ${{ matrix.tfm }}
@@ -18,18 +22,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tfm: [net8.0, net48]
+        tfm: [net8.0, net10.0, net48]
     env:
       DOTNET_NOLOGO: true
       DOTNET_CLI_TELEMETRY_OPTOUT: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: |
+            8.0.x
+            10.0.x
+          global-json-file: global.json
 
       - name: Configure endpoints
         shell: pwsh
@@ -44,25 +51,32 @@ jobs:
 
       - name: Upload Test Results (${{ matrix.tfm }})
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-windows-${{ matrix.tfm }}
           path: '**/TestResults-${{ matrix.tfm }}.trx'
 
   linux:
-    name: Kvaser (Ubuntu)
+    name: Kvaser (Ubuntu) – ${{ matrix.tfm }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tfm: [net8.0, net10.0]
     env:
       DOTNET_NOLOGO: true
       DOTNET_CLI_TELEMETRY_OPTOUT: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: |
+            8.0.x
+            10.0.x
+          global-json-file: global.json
       
       - name: Configure endpoints
         run: |
@@ -72,13 +86,13 @@ jobs:
       - name: Restore
         run: dotnet restore CanKitAdapters.slnf
 
-      - name: Test (net8.0)
-        run: dotnet test CanKitAdapters.slnf -c Fake -f net8.0 --logger "trx;LogFileName=TestResults.trx"
+      - name: Test (${{ matrix.tfm }})
+        run: dotnet test CanKitAdapters.slnf -c Fake -f ${{ matrix.tfm }} --logger "trx;LogFileName=TestResults-${{ matrix.tfm }}.trx"
 
-      - name: Upload Test Results
+      - name: Upload Test Results (${{ matrix.tfm }})
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: test-results-ubuntu
-          path: '**/TestResults.trx'
+          name: test-results-ubuntu-${{ matrix.tfm }}
+          path: '**/TestResults-${{ matrix.tfm }}.trx'
 

--- a/.github/workflows/nuget-pipeline.yml
+++ b/.github/workflows/nuget-pipeline.yml
@@ -7,6 +7,7 @@ on:
       - "tests/**"
       - "eng/**"
       - "CHANGELOG.md"
+      - "global.json"
       - ".github/workflows/nuget-pipeline.yml"
   push:
     branches:
@@ -18,6 +19,7 @@ on:
       - "tests/**"
       - "eng/**"
       - "CHANGELOG.md"
+      - "global.json"
       - ".github/workflows/nuget-pipeline.yml"
   workflow_dispatch:
 
@@ -39,14 +41,17 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: |
+            8.0.x
+            10.0.x
+          global-json-file: global.json
 
       - name: Resolve base ref
         id: refs
@@ -103,7 +108,7 @@ jobs:
         run: pwsh -File eng/scripts/Test-NuGetPackages.ps1
 
       - name: Upload NuGet artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nuget-artifacts
           path: artifacts/nuget/*
@@ -121,15 +126,18 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: |
+            8.0.x
+            10.0.x
+          global-json-file: global.json
 
       - name: Download NuGet artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: nuget-artifacts
           path: artifacts/nuget
@@ -160,10 +168,10 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download NuGet artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: nuget-artifacts
           path: artifacts/nuget

--- a/.github/workflows/pcan-ci.yml
+++ b/.github/workflows/pcan-ci.yml
@@ -6,11 +6,15 @@ on:
       - 'src/core/CanKit.Core/**'
       - 'src/adapters/CanKit.Adapter.PCAN/**'
       - 'tests/CanKit.Tests/**'
+      - 'src/Directory.Build.props'
+      - 'global.json'
   pull_request:
     paths:
       - 'src/core/CanKit.Core/**'
       - 'src/adapters/CanKit.Adapter.PCAN/**'
       - 'tests/CanKit.Tests/**'
+      - 'src/Directory.Build.props'
+      - 'global.json'
 jobs:
   windows:
     name: Pcan (windows) – ${{ matrix.tfm }}
@@ -18,18 +22,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tfm: [net8.0, net48]
+        tfm: [net8.0, net10.0, net48]
     env:
       DOTNET_NOLOGO: true
       DOTNET_CLI_TELEMETRY_OPTOUT: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: |
+            8.0.x
+            10.0.x
+          global-json-file: global.json
 
       - name: Configure endpoints
         shell: pwsh
@@ -44,25 +51,32 @@ jobs:
 
       - name: Upload Test Results (${{ matrix.tfm }})
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-windows-${{ matrix.tfm }}
           path: '**/TestResults-${{ matrix.tfm }}.trx'
 
   linux:
-    name: PCAN (Ubuntu)
+    name: PCAN (Ubuntu) – ${{ matrix.tfm }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tfm: [net8.0, net10.0]
     env:
       DOTNET_NOLOGO: true
       DOTNET_CLI_TELEMETRY_OPTOUT: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: |
+            8.0.x
+            10.0.x
+          global-json-file: global.json
       
       - name: Configure endpoints
         run: |
@@ -72,14 +86,14 @@ jobs:
       - name: Restore
         run: dotnet restore CanKitAdapters.slnf
 
-      - name: Test (net8.0)
-        run: dotnet test CanKitAdapters.slnf -c Fake -f net8.0 --logger "trx;LogFileName=TestResults.trx"
+      - name: Test (${{ matrix.tfm }})
+        run: dotnet test CanKitAdapters.slnf -c Fake -f ${{ matrix.tfm }} --logger "trx;LogFileName=TestResults-${{ matrix.tfm }}.trx"
 
-      - name: Upload Test Results
+      - name: Upload Test Results (${{ matrix.tfm }})
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: test-results-ubuntu
-          path: '**/TestResults.trx'
+          name: test-results-ubuntu-${{ matrix.tfm }}
+          path: '**/TestResults-${{ matrix.tfm }}.trx'
 
 

--- a/.github/workflows/socketcan-ci.yml
+++ b/.github/workflows/socketcan-ci.yml
@@ -6,26 +6,37 @@ on:
       - 'src/core/CanKit.Core/**'
       - 'src/adapters/CanKit.Adapter.SocketCAN/**'
       - 'tests/CanKit.Tests/**'
+      - 'src/Directory.Build.props'
+      - 'global.json'
   pull_request:
     paths:
       - 'src/core/CanKit.Core/**'
       - 'src/adapters/CanKit.Adapter.SocketCAN/**'
       - 'tests/CanKit.Tests/**'
+      - 'src/Directory.Build.props'
+      - 'global.json'
 jobs:
   linux:
-    name: SocketCAN (Ubuntu)
+    name: SocketCAN (Ubuntu) – ${{ matrix.tfm }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tfm: [net8.0, net10.0]
     env:
       DOTNET_NOLOGO: true
       DOTNET_CLI_TELEMETRY_OPTOUT: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: |
+            8.0.x
+            10.0.x
+          global-json-file: global.json
       
       - name: Configure endpoints
         run: |
@@ -35,13 +46,13 @@ jobs:
       - name: Restore
         run: dotnet restore CanKitAdapters.slnf
 
-      - name: Test (net8.0)
-        run: dotnet test CanKitAdapters.slnf -c Fake -f net8.0 --logger "trx;LogFileName=TestResults.trx"
+      - name: Test (${{ matrix.tfm }})
+        run: dotnet test CanKitAdapters.slnf -c Fake -f ${{ matrix.tfm }} --logger "trx;LogFileName=TestResults-${{ matrix.tfm }}.trx"
 
-      - name: Upload Test Results
+      - name: Upload Test Results (${{ matrix.tfm }})
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: test-results-ubuntu
-          path: '**/TestResults.trx'
+          name: test-results-ubuntu-${{ matrix.tfm }}
+          path: '**/TestResults-${{ matrix.tfm }}.trx'
 

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -11,7 +11,7 @@ jobs:
   labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: crazy-max/ghaction-github-labeler@v5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vector-ci.yml
+++ b/.github/workflows/vector-ci.yml
@@ -6,11 +6,15 @@ on:
       - 'src/core/CanKit.Core/**'
       - 'src/adapters/CanKit.Adapter.Vector/**'
       - 'tests/CanKit.Tests/**'
+      - 'src/Directory.Build.props'
+      - 'global.json'
   pull_request:
     paths:
       - 'src/core/CanKit.Core/**'
       - 'src/adapters/CanKit.Adapter.Vector/**'
       - 'tests/CanKit.Tests/**'
+      - 'src/Directory.Build.props'
+      - 'global.json'
 jobs:
   windows:
     name: Vector (windows) – ${{ matrix.tfm }}
@@ -18,18 +22,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tfm: [net8.0, net48]
+        tfm: [net8.0, net10.0, net48]
     env:
       DOTNET_NOLOGO: true
       DOTNET_CLI_TELEMETRY_OPTOUT: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: |
+            8.0.x
+            10.0.x
+          global-json-file: global.json
 
       - name: Configure endpoints
         shell: pwsh
@@ -44,25 +51,32 @@ jobs:
 
       - name: Upload Test Results (${{ matrix.tfm }})
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-windows-${{ matrix.tfm }}
           path: '**/TestResults-${{ matrix.tfm }}.trx'
 
   linux:
-    name: Vector (Ubuntu)
+    name: Vector (Ubuntu) – ${{ matrix.tfm }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tfm: [net8.0, net10.0]
     env:
       DOTNET_NOLOGO: true
       DOTNET_CLI_TELEMETRY_OPTOUT: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: |
+            8.0.x
+            10.0.x
+          global-json-file: global.json
       
       - name: Configure endpoints
         run: |
@@ -72,13 +86,13 @@ jobs:
       - name: Restore
         run: dotnet restore CanKitAdapters.slnf
 
-      - name: Test (net8.0)
-        run: dotnet test CanKitAdapters.slnf -c Fake -f net8.0 --logger "trx;LogFileName=TestResults.trx"
+      - name: Test (${{ matrix.tfm }})
+        run: dotnet test CanKitAdapters.slnf -c Fake -f ${{ matrix.tfm }} --logger "trx;LogFileName=TestResults-${{ matrix.tfm }}.trx"
 
-      - name: Upload Test Results
+      - name: Upload Test Results (${{ matrix.tfm }})
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: test-results-ubuntu
-          path: '**/TestResults.trx'
+          name: test-results-ubuntu-${{ matrix.tfm }}
+          path: '**/TestResults-${{ matrix.tfm }}.trx'
 

--- a/.github/workflows/virtual-ci.yml
+++ b/.github/workflows/virtual-ci.yml
@@ -6,11 +6,15 @@ on:
       - 'src/core/CanKit.Core/**'
       - 'src/adapters/CanKit.Adapter.Virtual/**'
       - 'tests/CanKit.Tests/**'
+      - 'src/Directory.Build.props'
+      - 'global.json'
   pull_request:
     paths:
       - 'src/core/CanKit.Core/**'
       - 'src/adapters/CanKit.Adapter.Virtual/**'
       - 'tests/CanKit.Tests/**'
+      - 'src/Directory.Build.props'
+      - 'global.json'
 jobs:
   windows:
     name: Virtual (windows) – ${{ matrix.tfm }}
@@ -18,18 +22,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tfm: [net8.0, net48]
+        tfm: [net8.0, net10.0, net48]
     env:
       DOTNET_NOLOGO: true
       DOTNET_CLI_TELEMETRY_OPTOUT: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: |
+            8.0.x
+            10.0.x
+          global-json-file: global.json
 
       - name: Configure endpoints
         shell: pwsh
@@ -44,25 +51,32 @@ jobs:
 
       - name: Upload Test Results (${{ matrix.tfm }})
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-windows-${{ matrix.tfm }}
           path: '**/TestResults-${{ matrix.tfm }}.trx'
           
   linux:
-    name: Virtual (Ubuntu)
+    name: Virtual (Ubuntu) – ${{ matrix.tfm }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tfm: [net8.0, net10.0]
     env:
       DOTNET_NOLOGO: true
       DOTNET_CLI_TELEMETRY_OPTOUT: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: |
+            8.0.x
+            10.0.x
+          global-json-file: global.json
       
       - name: Configure endpoints
         run: |
@@ -72,13 +86,13 @@ jobs:
       - name: Restore
         run: dotnet restore CanKitAdapters.slnf
 
-      - name: Test (net8.0)
-        run: dotnet test CanKitAdapters.slnf -c Release -f net8.0 --logger "trx;LogFileName=TestResults.trx"
+      - name: Test (${{ matrix.tfm }})
+        run: dotnet test CanKitAdapters.slnf -c Release -f ${{ matrix.tfm }} --logger "trx;LogFileName=TestResults-${{ matrix.tfm }}.trx"
 
-      - name: Upload Test Results
+      - name: Upload Test Results (${{ matrix.tfm }})
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: test-results-ubuntu
-          path: '**/TestResults.trx'
+          name: test-results-ubuntu-${{ matrix.tfm }}
+          path: '**/TestResults-${{ matrix.tfm }}.trx'
 

--- a/.github/workflows/zlg-ci.yml
+++ b/.github/workflows/zlg-ci.yml
@@ -6,11 +6,15 @@ on:
       - 'src/core/CanKit.Core/**'
       - 'src/adapters/CanKit.Adapter.ZLG/**'
       - 'tests/CanKit.Tests/**'
+      - 'src/Directory.Build.props'
+      - 'global.json'
   pull_request:
     paths:
       - 'src/core/CanKit.Core/**'
       - 'src/adapters/CanKit.Adapter.ZLG/**'
       - 'tests/CanKit.Tests/**'
+      - 'src/Directory.Build.props'
+      - 'global.json'
 jobs:
   windows:
     name: ZLGCAN (windows) – ${{ matrix.tfm }}
@@ -18,18 +22,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tfm: [net8.0, net48]
+        tfm: [net8.0, net10.0, net48]
     env:
       DOTNET_NOLOGO: true
       DOTNET_CLI_TELEMETRY_OPTOUT: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: |
+            8.0.x
+            10.0.x
+          global-json-file: global.json
 
       - name: Configure endpoints
         shell: pwsh
@@ -44,7 +51,7 @@ jobs:
 
       - name: Upload Test Results (${{ matrix.tfm }})
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-windows-${{ matrix.tfm }}
           path: '**/TestResults-${{ matrix.tfm }}.trx'

--- a/.gitignore
+++ b/.gitignore
@@ -363,4 +363,4 @@ MigrationBackup/
 FodyWeavers.xsd
 /.idea
 
-global.json
+# SDK pin lives in the repository (see global.json). Do not ignore it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for helping! This project aims to provide a single, clean C# API for CAN 
 
 ## Quick start (build & run)
 
-- Prereqs: .NET SDK 8.x
+- Prereqs: .NET SDK 10.x (pinned by `global.json` with `rollForward: latestFeature`). SDK 10 can still build and test the `net8.0` target.
 - Build: `dotnet build`
 - List available endpoints:  
   `dotnet run --project samples/CanKit.Sample.ListEndpoints`
@@ -14,6 +14,14 @@ Thanks for helping! This project aims to provide a single, clean C# API for CAN 
   `dotnet run --project samples/CanKit.Sample.QuickStartTxRx -- --src virtual://alpha/0 --dst virtual://alpha/1 --count 5`
 
 > The samples accept flags like `--scheme`, `--fd`, `--brs`, `--bitrate`, etc. See their `Program.cs` for full usage.
+
+## Target frameworks
+
+Library packages multi-target `netstandard2.0;net8.0;net8.0-windows;net10.0;net10.0-windows`. `net8.0` stays until its EOL (November 2026).
+
+Tests run on `net8.0` and `net10.0`. The `net48` test target is kept on purpose for Windows hardware tests against .NET Framework (vendor SDKs and classic Windows CAN stacks). It is not a library TFM.
+
+C# language version is 14, coupled to the SDK 10 pin.
 
 ## Filing issues
 
@@ -28,11 +36,11 @@ Thanks for helping! This project aims to provide a single, clean C# API for CAN 
 
 # Tests
 
-* **Run unit/integration tests:** `dotnet test`.
+* **Run unit/integration tests:** `dotnet test` (defaults to every test TFM). Hardware-free work is covered by `net8.0` / `net10.0`; use `-f net48` on Windows when exercising .NET Framework hardware tests.
   To run tests for a modified adapter, set `CANKIT_TEST_ADAPTERS` to the adapter’s project name.
 
 
-* **Adapter-specific dependencies:** Some adapter tests may require the vendor SDK and/or real hardware to be installed and connected.
+* **Adapter-specific dependencies:** Some adapter tests may require the vendor SDK and/or real hardware to be installed and connected. Test packages stay on xunit v2 (`2.9.x`) and FluentAssertions 7.x; FluentAssertions v8 is commercial (Xceed) for commercial use.
 
 * **Configurations:** You can run adapter tests with a **fake configuration** (no hardware). When conditions allow, prefer running in **Release** configuration against real hardware for end-to-end validation:
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![NuGet Downloads](https://img.shields.io/nuget/dt/CanKit.Core.svg?logo=nuget)](https://www.nuget.org/packages/CanKit.Core)
 [![.NET Standard 2.0](https://img.shields.io/badge/.NET%20Standard-2.0-512BD4?logo=dotnet&logoColor=white)](#)
 [![.NET 8](https://img.shields.io/badge/.NET-8.0-512BD4?logo=dotnet&logoColor=white)](#)
+[![.NET 10](https://img.shields.io/badge/.NET-10.0-512BD4?logo=dotnet&logoColor=white)](#)
 
 [![CI-adapter-vector](https://github.com/pkuyo/CanKit/actions/workflows/vector-ci.yml/badge.svg)](https://github.com/pkuyo/CanKit/actions/workflows/vector-ci.yml)
 [![CI-adapter-kvaser](https://github.com/pkuyo/CanKit/actions/workflows/kvaser-ci.yml/badge.svg)](https://github.com/pkuyo/CanKit/actions/workflows/kvaser-ci.yml)

--- a/README_CN.md
+++ b/README_CN.md
@@ -6,6 +6,7 @@
 [![NuGet Downloads](https://img.shields.io/nuget/dt/CanKit.Core.svg?logo=nuget)](https://www.nuget.org/packages/CanKit.Core)
 [![.NET Standard 2.0](https://img.shields.io/badge/.NET%20Standard-2.0-512BD4?logo=dotnet&logoColor=white)](#)
 [![.NET 8](https://img.shields.io/badge/.NET-8.0-512BD4?logo=dotnet&logoColor=white)](#)
+[![.NET 10](https://img.shields.io/badge/.NET-10.0-512BD4?logo=dotnet&logoColor=white)](#)
 
 [![CI-adapter-vector](https://github.com/pkuyo/CanKit/actions/workflows/vector-ci.yml/badge.svg)](https://github.com/pkuyo/CanKit/actions/workflows/vector-ci.yml)
 [![CI-adapter-kvaser](https://github.com/pkuyo/CanKit/actions/workflows/kvaser-ci.yml/badge.svg)](https://github.com/pkuyo/CanKit/actions/workflows/kvaser-ci.yml)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,6 +2,8 @@
 
 This guide walks through installing CanKit, choosing an adapter, opening a bus, and sending/receiving frames. English is the primary language for docs. If you prefer Chinese, use the Chinese README (README_CN.md) and Chinese docs when available.
 
+Building from source requires the .NET SDK 10.x pinned by `global.json`. Packages target `netstandard2.0`, `net8.0` / `net8.0-windows`, and `net10.0` / `net10.0-windows`.
+
 ## 1) Install Packages
 
 Install the core package, plus one or more adapter packages. Example package IDs (use published IDs in your feed):

--- a/docs/zh/getting-started.md
+++ b/docs/zh/getting-started.md
@@ -2,6 +2,8 @@
 
 本文介绍如何安装 CanKit、选择适配器、打开总线并完成基本的发送/接收。若需英文版文档，请参见 ../getting-started.md。
 
+从源码构建需要 `global.json` 锁定的 .NET SDK 10.x。发布包面向 `netstandard2.0`、`net8.0` / `net8.0-windows` 以及 `net10.0` / `net10.0-windows`。
+
 ## 1）安装 NuGet 包
 
 安装核心包，并按需安装一个或多个适配器包：

--- a/eng/package-smoke/CanKit.PackageSmoke.csproj
+++ b/eng/package-smoke/CanKit.PackageSmoke.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UseLocalProjectReferences Condition="'$(UseLocalProjectReferences)' == ''">true</UseLocalProjectReferences>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
+  }
+}

--- a/samples/CanKit.Sample.DualBusTest/CanKit.Sample.DualBusTest.csproj
+++ b/samples/CanKit.Sample.DualBusTest/CanKit.Sample.DualBusTest.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>CanKit.Sample.DualBusTest</RootNamespace>
     <Platforms>AnyCPU;x64;x86</Platforms>
-    <TargetFrameworks>net8.0;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0;net8.0-windows;net10.0;net10.0-windows</TargetFrameworks>
     <Configurations>Debug;Release;Fake</Configurations>
   </PropertyGroup>
 </Project>

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-      <TargetFrameworks>netstandard2.0;net8.0;net8.0-windows</TargetFrameworks>
-      <LangVersion>12</LangVersion>
+      <TargetFrameworks>netstandard2.0;net8.0;net8.0-windows;net10.0;net10.0-windows</TargetFrameworks>
+      <LangVersion>14</LangVersion>
       <EnableNETAnalyzers>true</EnableNETAnalyzers>
       <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
       <AnalysisLevel>latest</AnalysisLevel>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,8 +2,9 @@
   <Import Project="$(MSBuildThisFileDirectory)..\eng\package-versions.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0;net8.0-windows</TargetFrameworks>
-    <LangVersion>12</LangVersion>
+    <!-- net8.0 is kept until its EOL (November 2026). net10.0 is the current LTS. -->
+    <TargetFrameworks>netstandard2.0;net8.0;net8.0-windows;net10.0;net10.0-windows</TargetFrameworks>
+    <LangVersion>14</LangVersion>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisLevel>latest</AnalysisLevel>

--- a/src/adapters/CanKit.Adapter.PCAN/CanKit.Adapter.PCAN.csproj
+++ b/src/adapters/CanKit.Adapter.PCAN/CanKit.Adapter.PCAN.csproj
@@ -2,7 +2,6 @@
     <PropertyGroup>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
-        <LangVersion>12</LangVersion>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <Version>$(CanKitAdapterPCANVersion)</Version>
         <Description>Peak PCAN (PCAN-Basic) adapter for CanKit, providing unified bus access to PCAN hardware on Windows.</Description>

--- a/src/adapters/CanKit.Adapter.Virtual/CanKit.Adapter.Virtual.csproj
+++ b/src/adapters/CanKit.Adapter.Virtual/CanKit.Adapter.Virtual.csproj
@@ -2,7 +2,6 @@
     <PropertyGroup>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <LangVersion>12</LangVersion>
         <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
         <Version>$(CanKitAdapterVirtualVersion)</Version>
         <Description>Virtual in-process CAN adapter for CanKit for development, testing, and simulation.</Description>

--- a/src/core/CanKit.Abstractions/CanKit.Abstractions.csproj
+++ b/src/core/CanKit.Abstractions/CanKit.Abstractions.csproj
@@ -21,9 +21,9 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
-        <PackageReference Include="System.Memory" Version="4.5.4" />
+        <PackageReference Include="System.Memory" Version="4.6.3" />
         <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
-        <PackageReference Include="System.Threading.Channels" Version="9.0.10" />
+        <PackageReference Include="System.Threading.Channels" Version="10.0.11" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/core/CanKit.Core/CanKit.Core.csproj
+++ b/src/core/CanKit.Core/CanKit.Core.csproj
@@ -21,9 +21,9 @@
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
-	<PackageReference Include="System.Memory" Version="4.5.4" />
+	<PackageReference Include="System.Memory" Version="4.6.3" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
-    <PackageReference Include="System.Threading.Channels" Version="9.0.10" />
+    <PackageReference Include="System.Threading.Channels" Version="10.0.11" />
   </ItemGroup>
 
 

--- a/src/transports/CanKit.Transport.IsoTp/CanKit.Transport.IsoTp.csproj
+++ b/src/transports/CanKit.Transport.IsoTp/CanKit.Transport.IsoTp.csproj
@@ -2,7 +2,6 @@
     <PropertyGroup>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
-        <LangVersion>12</LangVersion>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <Version>$(CanKitTransportIsoTpVersion)</Version>
         <Description>TODO</Description>

--- a/tests/CanKit.Tests/CanKit.Tests.csproj
+++ b/tests/CanKit.Tests/CanKit.Tests.csproj
@@ -3,20 +3,22 @@
     <IsPackable>false</IsPackable>
     <AssemblyName>CanKit.Tests</AssemblyName>
     <RootNamespace>CanKit.Tests</RootNamespace>
-    <LangVersion>12</LangVersion>
+    <LangVersion>14</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks Condition="'$(Configuration)' == 'Fake'">true</AllowUnsafeBlocks>
     <DefineConstants Condition="'$(Configuration)' == 'Fake'">$(DefineConstants);FAKE</DefineConstants>
-    <TargetFrameworks>net8.0;net48</TargetFrameworks>
+    <!-- net48 is kept on purpose for Windows hardware tests against .NET Framework. -->
+    <TargetFrameworks>net8.0;net10.0;net48</TargetFrameworks>
     <Configurations>Debug;Release;Fake</Configurations>
     <Platforms>AnyCPU;X86;X64</Platforms>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="xunit" Version="2.9.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <!-- FluentAssertions v8+ is commercial (Xceed) for commercial use; stay on the last 7.x OSS line. -->
+    <PackageReference Include="FluentAssertions" Version="[7.2.2,8.0.0)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Closes pkuyo/CanKit#19.

Toolchain modernization on a current copy of upstream `master` (`bec6c33` / v0.5.6): .NET 10 support, C# 14, dependency and GitHub Actions updates, Dependabot, and contributing/build prerequisite docs.

## Type
- [ ] Bug fix
- [x] Feature
- [x] Docs
- [ ] Adapter-specific (PCAN/Kvaser/SocketCAN/ZLG)

## TFM matrix

Library packages now target:

`netstandard2.0;net8.0;net8.0-windows;net10.0;net10.0-windows`

- `net8.0` is kept until its EOL (November 2026).
- `net10.0` / `net10.0-windows` are first-class LTS targets for consumers already on .NET 10.

Tests target `net8.0;net10.0;net48`.

**`net48` is kept on purpose** for Windows hardware tests against .NET Framework (vendor SDKs and classic Windows CAN stacks). It is not a library TFM.

CI installs both `8.0.x` and `10.0.x` and uses `global.json` (`SDK 10.0.100`, `rollForward: latestFeature`, `allowPrerelease: false`) so SDK 10 builds every TFM. Windows adapter jobs exercise `net8.0`, `net10.0`, and `net48`; Linux jobs exercise `net8.0` and `net10.0`.

## FluentAssertions pin

Starting with v8, FluentAssertions is commercial (Xceed) for commercial use. Tests stay on the last 7.x OSS line (`[7.2.2,8.0.0)`). Dependabot is configured to ignore FluentAssertions >= 8. xunit stays on the 2.9.x patch line (not v3).

## Other changes

- `LangVersion` 14, coupled to the SDK 10 pin.
- `Microsoft.NET.Test.Sdk` 18.9.0, `xunit` 2.9.3, `xunit.runner.visualstudio` 3.1.5.
- `System.Memory` 4.6.3 and `System.Threading.Channels` 10.0.11 on the netstandard2.0 leg.
- GitHub Actions: `checkout@v7`, `setup-dotnet@v6`, `upload-artifact@v7`, `download-artifact@v8`.
- Dependabot for NuGet + GitHub Actions (weekly).
- Contributing / getting-started / README / issue templates updated for SDK 10 and the TFM matrix.

Issue #19 suggested staged PRs; this is one branch so the SDK, TFMs, CI matrix, and docs stay consistent and CI can stay green.

## Tests

`dotnet build CanKit.sln -c Release` succeeds for all library TFMs including `net10.0` / `net10.0-windows` (packages contain `lib/net10.0` and `lib/net10.0-windows7.0`). Hardware-free tests:

- Virtual Release `net8.0`: 80 passed
- Virtual Release `net10.0`: 80 passed
- ZLG Fake `net10.0`: 156 passed
- SocketCAN Fake `net10.0`: 86 passed
- ControlCAN Fake `net10.0`: 76 passed

GitHub Actions on this PR: adapter jobs for `net8.0` / `net10.0` / `net48` and NuGet `pack_validate` are green.

## Checklist
- [x] Uses Conventional Commits in title (e.g., `feat(core): ...`)
- [x] Builds & tests pass locally (`dotnet build`, `dotnet test`)
- [x] Updated docs / samples if behavior changed
- [x] Linked related issues
