### PR TITLE
feat(test): upgrade CanKit.Tests to xUnit.net v3

### DIFF
--- a/.github/workflows/controlcan-ci.yml
+++ b/.github/workflows/controlcan-ci.yml
@@ -47,7 +47,7 @@ jobs:
         run: dotnet restore CanKitAdapters.slnf
 
       - name: Test (${{ matrix.tfm }})
-        run: dotnet test CanKitAdapters.slnf -c Fake -f ${{ matrix.tfm }} --logger "trx;LogFileName=TestResults-${{ matrix.tfm }}.trx"
+        run: dotnet test --solution CanKitAdapters.slnf -c Fake -f ${{ matrix.tfm }} --report-trx --report-trx-filename TestResults-${{ matrix.tfm }}.trx
 
       - name: Upload Test Results (${{ matrix.tfm }})
         if: always()

--- a/.github/workflows/kvaser-ci.yml
+++ b/.github/workflows/kvaser-ci.yml
@@ -47,7 +47,7 @@ jobs:
         run: dotnet restore CanKitAdapters.slnf
 
       - name: Test (${{ matrix.tfm }})
-        run: dotnet test CanKitAdapters.slnf -c Fake -f ${{ matrix.tfm }} --logger "trx;LogFileName=TestResults-${{ matrix.tfm }}.trx"
+        run: dotnet test --solution CanKitAdapters.slnf -c Fake -f ${{ matrix.tfm }} --report-trx --report-trx-filename TestResults-${{ matrix.tfm }}.trx
 
       - name: Upload Test Results (${{ matrix.tfm }})
         if: always()
@@ -87,7 +87,7 @@ jobs:
         run: dotnet restore CanKitAdapters.slnf
 
       - name: Test (${{ matrix.tfm }})
-        run: dotnet test CanKitAdapters.slnf -c Fake -f ${{ matrix.tfm }} --logger "trx;LogFileName=TestResults-${{ matrix.tfm }}.trx"
+        run: dotnet test --solution CanKitAdapters.slnf -c Fake -f ${{ matrix.tfm }} --report-trx --report-trx-filename TestResults-${{ matrix.tfm }}.trx
 
       - name: Upload Test Results (${{ matrix.tfm }})
         if: always()

--- a/.github/workflows/pcan-ci.yml
+++ b/.github/workflows/pcan-ci.yml
@@ -47,7 +47,7 @@ jobs:
         run: dotnet restore CanKitAdapters.slnf
 
       - name: Test (${{ matrix.tfm }})
-        run: dotnet test CanKitAdapters.slnf -c Fake -f ${{ matrix.tfm }} --logger "trx;LogFileName=TestResults-${{ matrix.tfm }}.trx"
+        run: dotnet test --solution CanKitAdapters.slnf -c Fake -f ${{ matrix.tfm }} --report-trx --report-trx-filename TestResults-${{ matrix.tfm }}.trx
 
       - name: Upload Test Results (${{ matrix.tfm }})
         if: always()
@@ -87,7 +87,7 @@ jobs:
         run: dotnet restore CanKitAdapters.slnf
 
       - name: Test (${{ matrix.tfm }})
-        run: dotnet test CanKitAdapters.slnf -c Fake -f ${{ matrix.tfm }} --logger "trx;LogFileName=TestResults-${{ matrix.tfm }}.trx"
+        run: dotnet test --solution CanKitAdapters.slnf -c Fake -f ${{ matrix.tfm }} --report-trx --report-trx-filename TestResults-${{ matrix.tfm }}.trx
 
       - name: Upload Test Results (${{ matrix.tfm }})
         if: always()

--- a/.github/workflows/socketcan-ci.yml
+++ b/.github/workflows/socketcan-ci.yml
@@ -47,7 +47,7 @@ jobs:
         run: dotnet restore CanKitAdapters.slnf
 
       - name: Test (${{ matrix.tfm }})
-        run: dotnet test CanKitAdapters.slnf -c Fake -f ${{ matrix.tfm }} --logger "trx;LogFileName=TestResults-${{ matrix.tfm }}.trx"
+        run: dotnet test --solution CanKitAdapters.slnf -c Fake -f ${{ matrix.tfm }} --report-trx --report-trx-filename TestResults-${{ matrix.tfm }}.trx
 
       - name: Upload Test Results (${{ matrix.tfm }})
         if: always()

--- a/.github/workflows/vector-ci.yml
+++ b/.github/workflows/vector-ci.yml
@@ -47,7 +47,7 @@ jobs:
         run: dotnet restore CanKitAdapters.slnf
 
       - name: Test (${{ matrix.tfm }})
-        run: dotnet test CanKitAdapters.slnf -c Fake -f ${{ matrix.tfm }} --logger "trx;LogFileName=TestResults-${{ matrix.tfm }}.trx"
+        run: dotnet test --solution CanKitAdapters.slnf -c Fake -f ${{ matrix.tfm }} --report-trx --report-trx-filename TestResults-${{ matrix.tfm }}.trx
 
       - name: Upload Test Results (${{ matrix.tfm }})
         if: always()
@@ -87,7 +87,7 @@ jobs:
         run: dotnet restore CanKitAdapters.slnf
 
       - name: Test (${{ matrix.tfm }})
-        run: dotnet test CanKitAdapters.slnf -c Fake -f ${{ matrix.tfm }} --logger "trx;LogFileName=TestResults-${{ matrix.tfm }}.trx"
+        run: dotnet test --solution CanKitAdapters.slnf -c Fake -f ${{ matrix.tfm }} --report-trx --report-trx-filename TestResults-${{ matrix.tfm }}.trx
 
       - name: Upload Test Results (${{ matrix.tfm }})
         if: always()

--- a/.github/workflows/virtual-ci.yml
+++ b/.github/workflows/virtual-ci.yml
@@ -47,7 +47,7 @@ jobs:
         run: dotnet restore CanKitAdapters.slnf
 
       - name: Test (${{ matrix.tfm }})
-        run: dotnet test CanKitAdapters.slnf -c Release -f ${{ matrix.tfm }} --logger "trx;LogFileName=TestResults-${{ matrix.tfm }}.trx"
+        run: dotnet test --solution CanKitAdapters.slnf -c Release -f ${{ matrix.tfm }} --report-trx --report-trx-filename TestResults-${{ matrix.tfm }}.trx
 
       - name: Upload Test Results (${{ matrix.tfm }})
         if: always()
@@ -87,7 +87,7 @@ jobs:
         run: dotnet restore CanKitAdapters.slnf
 
       - name: Test (${{ matrix.tfm }})
-        run: dotnet test CanKitAdapters.slnf -c Release -f ${{ matrix.tfm }} --logger "trx;LogFileName=TestResults-${{ matrix.tfm }}.trx"
+        run: dotnet test --solution CanKitAdapters.slnf -c Release -f ${{ matrix.tfm }} --report-trx --report-trx-filename TestResults-${{ matrix.tfm }}.trx
 
       - name: Upload Test Results (${{ matrix.tfm }})
         if: always()

--- a/.github/workflows/zlg-ci.yml
+++ b/.github/workflows/zlg-ci.yml
@@ -47,7 +47,7 @@ jobs:
         run: dotnet restore CanKitAdapters.slnf
 
       - name: Test (${{ matrix.tfm }})
-        run: dotnet test CanKitAdapters.slnf -c Fake -f ${{ matrix.tfm }} --logger "trx;LogFileName=TestResults-${{ matrix.tfm }}.trx"
+        run: dotnet test --solution CanKitAdapters.slnf -c Fake -f ${{ matrix.tfm }} --report-trx --report-trx-filename TestResults-${{ matrix.tfm }}.trx
 
       - name: Upload Test Results (${{ matrix.tfm }})
         if: always()

--- a/global.json
+++ b/global.json
@@ -3,5 +3,8 @@
     "version": "10.0.100",
     "rollForward": "latestFeature",
     "allowPrerelease": false
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
   }
 }

--- a/tests/CanKit.Tests/CanKit.Tests.csproj
+++ b/tests/CanKit.Tests/CanKit.Tests.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <AssemblyName>CanKit.Tests</AssemblyName>
     <RootNamespace>CanKit.Tests</RootNamespace>
@@ -15,8 +16,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0" />
     <!-- FluentAssertions v8+ is commercial (Xceed) for commercial use; stay on the last 7.x OSS line. -->
     <PackageReference Include="FluentAssertions" Version="[7.2.2,8.0.0)" />
   </ItemGroup>
@@ -32,4 +33,3 @@
     <ProjectReference Include="..\..\src\adapters\CanKit.Adapter.ZLG\CanKit.Adapter.ZLG.csproj" />
   </ItemGroup>
 </Project>
-

--- a/tests/CanKit.Tests/CanKit.Tests.csproj
+++ b/tests/CanKit.Tests/CanKit.Tests.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="2.3.3" />
     <PackageReference Include="xunit.v3" Version="4.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0" />
     <!-- FluentAssertions v8+ is commercial (Xceed) for commercial use; stay on the last 7.x OSS line. -->

--- a/tests/CanKit.Tests/Matrix/FilterMatrix.cs
+++ b/tests/CanKit.Tests/Matrix/FilterMatrix.cs
@@ -7,16 +7,22 @@ namespace CanKit.Tests.Matrix;
 
 public partial class TestMatrix
 {
-    public static IEnumerable<object[]> CombinedRangeFilter()
+    public static IEnumerable<object> CombinedRangeFilter()
+        => SkipWhenEmpty(CombinedRangeFilterRows());
+
+    private static IEnumerable<object[]> CombinedRangeFilterRows()
     {
-        foreach (var i in Pairs())
+        foreach (var i in PairRows())
         foreach (var l in RangeCases())
             yield return i.Concat(l).ToArray();
     }
 
-    public static IEnumerable<object[]> CombinedMaskFilter()
+    public static IEnumerable<object> CombinedMaskFilter()
+        => SkipWhenEmpty(CombinedMaskFilterRows());
+
+    private static IEnumerable<object[]> CombinedMaskFilterRows()
     {
-        foreach (var i in Pairs())
+        foreach (var i in PairRows())
         foreach (var l in MaskCases())
             yield return i.Concat(l).ToArray();
     }

--- a/tests/CanKit.Tests/Matrix/PeriodicMatrix.cs
+++ b/tests/CanKit.Tests/Matrix/PeriodicMatrix.cs
@@ -9,16 +9,22 @@ namespace CanKit.Tests.Matrix;
 
 public partial class TestMatrix
 {
-    public static IEnumerable<object[]> CombinedPeriodicCount()
+    public static IEnumerable<object> CombinedPeriodicCount()
+        => SkipWhenEmpty(CombinedPeriodicCountRows());
+
+    private static IEnumerable<object[]> CombinedPeriodicCountRows()
     {
-        foreach(var i in Pairs())
+        foreach (var i in PairRows())
         foreach (var l in PeriodicCountCases())
             yield return i.Concat(l).ToArray();
     }
 
-    public static IEnumerable<object[]> CombinedPeriodicPeriod()
+    public static IEnumerable<object> CombinedPeriodicPeriod()
+        => SkipWhenEmpty(CombinedPeriodicPeriodRows());
+
+    private static IEnumerable<object[]> CombinedPeriodicPeriodRows()
     {
-        foreach(var i in Pairs())
+        foreach (var i in PairRows())
         foreach (var l in PeriodicPeriodCases())
             yield return i.Concat(l).ToArray();
     }

--- a/tests/CanKit.Tests/Matrix/TestMatrix.cs
+++ b/tests/CanKit.Tests/Matrix/TestMatrix.cs
@@ -1,16 +1,29 @@
 using System.Collections.Generic;
-using System.Linq;
+using Xunit;
 
 namespace CanKit.Tests.Matrix;
 
 public static partial class TestMatrix
 {
+    internal static IEnumerable<object> SkipWhenEmpty(IEnumerable<object[]> rows)
+    {
+        var any = false;
+        foreach (var row in rows)
+        {
+            any = true;
+            yield return row;
+        }
 
-    public static IEnumerable<object[]> Pairs()
+        if (!any && TestCaseProvider.MissingAdapterSkipReason is { } reason)
+            yield return new TheoryDataRow().WithSkip(reason);
+    }
+
+    public static IEnumerable<object> Pairs()
+        => SkipWhenEmpty(PairRows());
+
+    internal static IEnumerable<object[]> PairRows()
     {
         foreach (var endpoint in TestCaseProvider.Provider.EndpointPairs)
-            yield return [endpoint.epA, endpoint.epB,$"{endpoint.epA}->{endpoint.epB}", endpoint.isFd];
+            yield return [endpoint.epA, endpoint.epB, $"{endpoint.epA}->{endpoint.epB}", endpoint.isFd];
     }
 }
-
-

--- a/tests/CanKit.Tests/Matrix/TransceiverMatrix.cs
+++ b/tests/CanKit.Tests/Matrix/TransceiverMatrix.cs
@@ -5,31 +5,43 @@ namespace CanKit.Tests.Matrix;
 
 public partial class TestMatrix
 {
-    public static IEnumerable<object[]> CombinedOneShotClassic()
+    public static IEnumerable<object> CombinedOneShotClassic()
+        => SkipWhenEmpty(CombinedOneShotClassicRows());
+
+    private static IEnumerable<object[]> CombinedOneShotClassicRows()
     {
-        foreach(var i in Pairs())
+        foreach (var i in PairRows())
         foreach (var r in ClassicFrameSettings())
             yield return i.Concat(r).ToArray();
     }
 
-    public static IEnumerable<object[]> CombinedOneShotFD()
+    public static IEnumerable<object> CombinedOneShotFD()
+        => SkipWhenEmpty(CombinedOneShotFDRows());
+
+    private static IEnumerable<object[]> CombinedOneShotFDRows()
     {
-        foreach(var i in Pairs())
+        foreach (var i in PairRows())
         foreach (var r in FDFrameSettings())
             yield return i.Concat(r).ToArray();
     }
 
-    public static IEnumerable<object[]> CombinedContinuosClassic()
+    public static IEnumerable<object> CombinedContinuosClassic()
+        => SkipWhenEmpty(CombinedContinuosClassicRows());
+
+    private static IEnumerable<object[]> CombinedContinuosClassicRows()
     {
-        foreach(var i in Pairs())
+        foreach (var i in PairRows())
         foreach (var l in GapCases())
         foreach (var r in ClassicFrameSettings())
             yield return i.Concat(l).Concat(r).ToArray();
     }
 
-    public static IEnumerable<object[]> CombinedContinuosFD()
+    public static IEnumerable<object> CombinedContinuosFD()
+        => SkipWhenEmpty(CombinedContinuosFDRows());
+
+    private static IEnumerable<object[]> CombinedContinuosFDRows()
     {
-        foreach(var i in Pairs())
+        foreach (var i in PairRows())
         foreach (var l in GapCases())
         foreach (var r in FDFrameSettings())
             yield return i.Concat(l).Concat(r).ToArray();

--- a/tests/CanKit.Tests/Properties/AssemblyInfo.cs
+++ b/tests/CanKit.Tests/Properties/AssemblyInfo.cs
@@ -1,3 +1,4 @@
-using Xunit;
-[assembly: CollectionBehavior(DisableTestParallelization = true, MaxParallelThreads = 1)]
+using Xunit.Sdk;
+using Xunit.v3;
 
+[assembly: Parallelization(Mode = ParallelMode.None)]

--- a/tests/CanKit.Tests/TestCaseProvider.cs
+++ b/tests/CanKit.Tests/TestCaseProvider.cs
@@ -27,7 +27,8 @@ public class TestCaseProvider : IDisposable
         var env = Environment.GetEnvironmentVariable("CANKIT_TEST_ADAPTERS");
         if (env is null)
         {
-            Console.WriteLine($"No environment variable found. Skipping all tests.");
+            Console.WriteLine("No environment variable found. Skipping all tests.");
+            MissingAdapterSkipReason = "No test adapter configured (CANKIT_TEST_ADAPTERS).";
             return;
         }
 
@@ -53,6 +54,12 @@ public class TestCaseProvider : IDisposable
     public static int DbitRate { get; }
 
     public static ITestDataProvider Provider { get; }
+
+    /// <summary>
+    /// Set only when CANKIT_TEST_ADAPTERS is unset. A configured adapter that
+    /// fails to load keeps this null so empty theory data stays a failure.
+    /// </summary>
+    public static string? MissingAdapterSkipReason { get; }
 
     public static Random Rand { get; } = new Random();
 

--- a/tests/CanKit.Tests/TestCases/PeriodicTests.cs
+++ b/tests/CanKit.Tests/TestCases/PeriodicTests.cs
@@ -43,19 +43,20 @@ public class PeriodicTests : IClassFixture<TestCaseProvider>
 
             using var handle = tx.TransmitPeriodic(frame, options);
 
+            var ct = TestContext.Current.CancellationToken;
             var received = 0;
             var end = DateTime.UtcNow.AddSeconds(2);
             while (DateTime.UtcNow < end && received < count)
             {
-                var batch = await rx.ReceiveAsync(16, 20);
+                var batch = await rx.ReceiveAsync(16, 20, ct);
                 received += batch.Count(d => d.CanFrame.ID == frame.ID);
             }
 
             // Stop and ensure no more
             handle.Stop();
             received.Should().BeGreaterOrEqualTo(count);
-            await Task.Delay(period.Milliseconds*5);
-            var after = await rx.ReceiveAsync(16, 100);
+            await Task.Delay(period.Milliseconds * 5, ct);
+            var after = await rx.ReceiveAsync(16, 100, ct);
             after.Count(d => d.CanFrame.ID == frame.ID).Should().BeLessOrEqualTo(1);
         }
         finally

--- a/tests/CanKit.Tests/TestCases/PeriodicTests.cs
+++ b/tests/CanKit.Tests/TestCases/PeriodicTests.cs
@@ -55,7 +55,7 @@ public class PeriodicTests : IClassFixture<TestCaseProvider>
             // Stop and ensure no more
             handle.Stop();
             received.Should().BeGreaterOrEqualTo(count);
-            await Task.Delay(period.Milliseconds * 5, ct);
+            await Task.Delay(TimeSpan.FromMilliseconds(period.TotalMilliseconds * 5), ct);
             var after = await rx.ReceiveAsync(16, 100, ct);
             after.Count(d => d.CanFrame.ID == frame.ID).Should().BeLessOrEqualTo(1);
         }

--- a/tests/CanKit.Tests/TestCases/SocketCanBcmOwnershipTests.cs
+++ b/tests/CanKit.Tests/TestCases/SocketCanBcmOwnershipTests.cs
@@ -254,7 +254,7 @@ public class SocketCanBcmOwnershipTests
             Action queryRemaining = () => _ = handle!.RemainingCount;
             queryRemaining.Should().NotThrow();
 
-            await Task.Delay(40);
+            await Task.Delay(40, TestContext.Current.CancellationToken);
         }
         finally
         {

--- a/tests/CanKit.Tests/TestCases/ZlgFakeNativeReceiveTests.cs
+++ b/tests/CanKit.Tests/TestCases/ZlgFakeNativeReceiveTests.cs
@@ -49,13 +49,14 @@ public class ZlgFakeNativeReceiveTests
             rx,
             receiveStarted);
 
+        var ct = TestContext.Current.CancellationToken;
         await receiveStarted.Task;
-        await Task.Delay(50);
+        await Task.Delay(50, ct);
         Transmit(rx, receiveKind, 0x101);
-        await Task.Delay(50);
+        await Task.Delay(50, ct);
         Transmit(rx, receiveKind, 0x102);
 
-        var completed = await Task.WhenAny(receiveTask, Task.Delay(TimeSpan.FromSeconds(2)));
+        var completed = await Task.WhenAny(receiveTask, Task.Delay(TimeSpan.FromSeconds(2), ct));
         completed.Should().Be(receiveTask, "the infinite-wait receive should finish once the batch arrives");
         var received = await receiveTask;
         received.Should().Be(2);


### PR DESCRIPTION
## Summary
- Replace `xunit` 2.9.3 with `xunit.v3` 4.0.0. The test project is an executable now, and `CollectionBehavior` is `Parallelization(Mode = None)`.
- Opt `dotnet test` into Microsoft.Testing.Platform (`global.json`). Adapter CI writes TRX via `--report-trx`. `xunit.runner.visualstudio` and `Microsoft.NET.Test.Sdk` stay for Test Explorer.
- Empty MemberData is a skip only when `CANKIT_TEST_ADAPTERS` is unset. A configured adapter that fails to load still fails the run.
- Pass `TestContext.Current.CancellationToken` into `Task.Delay` / `ReceiveAsync` (xUnit1051). The periodic post-stop wait uses `TotalMilliseconds`.

`net8.0`, `net10.0`, and `net48` are unchanged. FluentAssertions stays on 7.x.

Fixes #38

## Test plan
- [x] `dotnet test --project tests/CanKit.Tests/CanKit.Tests.csproj -c Fake -f net10.0` with no adapter env (48 passed, 9 skipped)
- [x] `dotnet build tests/CanKit.Tests/CanKit.Tests.csproj -c Fake -f net48`
- [x] Adapter CI (Fake + Virtual) after this PR is up