### PR TITLE
test: allow 0.1% loss on continuous burst GapCases

### DIFF
--- a/tests/CanKit.Tests/Matrix/TransceiverMatrix.cs
+++ b/tests/CanKit.Tests/Matrix/TransceiverMatrix.cs
@@ -41,7 +41,7 @@ public partial class TestMatrix
     private static IEnumerable<object[]> GapCases()
     {
         // (gapMs, lossLimit)
-        yield return [1, 0.0]; // gap=1ms, loss < 0.1%
+        yield return [1, 0.001]; // gap=1ms, loss < 0.1%
     }
 
 


### PR DESCRIPTION
## Summary
- `GapCases` documented `loss < 0.1%` but passed `0.0`. One dropped frame in a 6000-frame burst (`≈ 0.0167%`) failed `Continuous_Fd_Over5000_With_Gap_And_Loss` on Kvaser Fake CI.
- Set `lossLimit` to `0.001` so it matches the comment. Classic and FD continuous theories share this row.

Fixes #40

## Test plan
- [x] Kvaser Fake CI (`Continuous_Fd_Over5000_With_Gap_And_Loss`, `kvaser://0` → `kvaser://1`)
- [x] Other adapter Fake continuous-burst jobs still green