### PR TITLE
fix(controlcan): compare batch TX writes per call and marshal VCI_Receive as Out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Vendor adapters wrap a missing or wrong-bitness native library (`DllNotFoundException` / `BadImageFormatException`) at the first Open/constructor native call as adapter-specific `CanNativeCallException` types, with `CanKitErrorCode.NativeLibraryNotFound`, the original exception retained, and a message that names the DLL and the vendor runtime. Fake builds are unchanged.
 
+### Fixed
+
+* ControlCAN batch `Transmit` compared the running write total to `BATCH_COUNT` (64), so a second full native batch aborted the rest of the payload (128 frames sent, remainder dropped). The short-write check now uses this `VCI_Transmit` call's return value. `VCI_Receive` marshals the receive array as `[Out]` so native fills copy back into managed memory.
+
 ## 0.5.6
 
 Published packages:

--- a/src/adapters/CanKit.Adapter.ControlCAN/ControlCanTransceiver.cs
+++ b/src/adapters/CanKit.Adapter.ControlCAN/ControlCanTransceiver.cs
@@ -28,8 +28,9 @@ internal sealed class ControlCanTransceiver : ITransceiver
             f.ToNative(&pObj[index++], retry);
             if (index == CcApi.BATCH_COUNT)
             {
-                written += CcApi.VCI_Transmit(ctl.RawDevType, ctl.DevIndex, ctl.CanIndex, pObj, CcApi.BATCH_COUNT);
-                if (written != CcApi.BATCH_COUNT)
+                var n = CcApi.VCI_Transmit(ctl.RawDevType, ctl.DevIndex, ctl.CanIndex, pObj, CcApi.BATCH_COUNT);
+                written += n;
+                if (n != CcApi.BATCH_COUNT)
                     return (int)written;
                 index = 0;
             }
@@ -37,7 +38,10 @@ internal sealed class ControlCanTransceiver : ITransceiver
 
         if (index != 0)
         {
-            written += CcApi.VCI_Transmit(ctl.RawDevType, ctl.DevIndex, ctl.CanIndex, pObj, (uint)index);
+            var n = CcApi.VCI_Transmit(ctl.RawDevType, ctl.DevIndex, ctl.CanIndex, pObj, (uint)index);
+            written += n;
+            if (n != (uint)index)
+                return (int)written;
         }
         return (int)written;
     }
@@ -57,8 +61,9 @@ internal sealed class ControlCanTransceiver : ITransceiver
             f.ToNative(&pObj[index++], retry);
             if (index == CcApi.BATCH_COUNT)
             {
-                written += CcApi.VCI_Transmit(ctl.RawDevType, ctl.DevIndex, ctl.CanIndex, pObj, CcApi.BATCH_COUNT);
-                if (written != CcApi.BATCH_COUNT)
+                var n = CcApi.VCI_Transmit(ctl.RawDevType, ctl.DevIndex, ctl.CanIndex, pObj, CcApi.BATCH_COUNT);
+                written += n;
+                if (n != CcApi.BATCH_COUNT)
                     return (int)written;
                 index = 0;
             }
@@ -66,7 +71,10 @@ internal sealed class ControlCanTransceiver : ITransceiver
 
         if (index != 0)
         {
-            written += CcApi.VCI_Transmit(ctl.RawDevType, ctl.DevIndex, ctl.CanIndex, pObj, (uint)index);
+            var n = CcApi.VCI_Transmit(ctl.RawDevType, ctl.DevIndex, ctl.CanIndex, pObj, (uint)index);
+            written += n;
+            if (n != (uint)index)
+                return (int)written;
         }
         return (int)written;
     }
@@ -110,4 +118,3 @@ internal sealed class ControlCanTransceiver : ITransceiver
         }
     }
 }
-

--- a/src/adapters/CanKit.Adapter.ControlCAN/Native/ControlCAN.cs
+++ b/src/adapters/CanKit.Adapter.ControlCAN/Native/ControlCAN.cs
@@ -103,7 +103,7 @@ internal static class ControlCAN
     public static unsafe extern uint VCI_Transmit(uint DevType, uint DevIndex, uint CANIndex, VCI_CAN_OBJ* pSend, uint Len);
 
     [DllImport(DllName)]
-    public static extern uint VCI_Receive(uint DevType, uint DevIndex, uint CANIndex, VCI_CAN_OBJ[] pReceive, uint Len, int WaitTime);
+    public static extern uint VCI_Receive(uint DevType, uint DevIndex, uint CANIndex, [Out] VCI_CAN_OBJ[] pReceive, uint Len, int WaitTime);
 
     [DllImport(DllName)]
     public static extern uint VCI_ReadErrInfo(uint DevType, uint DevIndex, uint CANIndex, out VCI_ERR_INFO pErrInfo);

--- a/tests/CanKit.Tests/TestCases/TransceiverTests.cs
+++ b/tests/CanKit.Tests/TestCases/TransceiverTests.cs
@@ -44,6 +44,41 @@ public class ThroughputAndFeaturesTests : IClassFixture<TestCaseProvider>
             v.BadData.Should().Be(0);
         }
     }
+
+    // Direct Transmit of 130 frames (2 * ControlCAN BATCH_COUNT + 2). The existing
+    // 64/128 one-shot test sends through SendBurstAsync in chunks of 32, so it would
+    // not catch a transceiver that compares the running write total to BATCH_COUNT.
+    [Theory]
+    [MemberData(nameof(Matrix.TestMatrix.Pairs), MemberType = typeof(Matrix.TestMatrix))]
+    public async Task Transmit_Past_Two_Native_Batches_Returns_Full_Count(
+        string epA, string epB, string endpoint, bool hasFd)
+    {
+        _ = endpoint;
+        _ = hasFd;
+        using var rx = TestHelpers.OpenClassic(epA);
+        using var tx = TestHelpers.OpenClassic(epB);
+
+        const int count = 130;
+        var frames = TestHelpers.GenerateSeqFrames(
+            TestHelpers.CreateClassicSeq(0x100, false, false, 8), count).ToArray();
+
+        tx.Transmit(frames).Should().Be(count);
+        using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2)))
+        {
+            var rec = await TestHelpers.ReceiveUntilAsync(
+                rx, new TestHelpers.SequenceVerifier(), count, 2000, cts.Token);
+            rec.Should().Be(count);
+        }
+
+        tx.Transmit((IEnumerable<CanFrame>)frames).Should().Be(count);
+        using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2)))
+        {
+            var rec = await TestHelpers.ReceiveUntilAsync(
+                rx, new TestHelpers.SequenceVerifier(), count, 2000, cts.Token);
+            rec.Should().Be(count);
+        }
+    }
+
     // 64 and 128 one-shot batch (FD)
     // 单次64和128的发送批次（CANFD）
     [Theory]


### PR DESCRIPTION
## Summary
ControlCAN batch `Transmit` compared the running `written` total to `BATCH_COUNT` (64), so a second full native batch aborted the rest of the payload (128 frames sent, remainder dropped). The short-write check now uses this `VCI_Transmit` call's return value, including the leftover partial batch.

`VCI_Receive` marshals the receive array as `[Out]` so native fills copy back into managed memory (the default `[In]` left the managed array as zeros).

Fake coverage: 130-frame one-shot `Transmit` (span and `IEnumerable`) must return 130, not 128. `[Out]` still needs a hardware receive check.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Docs
- [x] Adapter-specific (PCAN/Kvaser/SocketCAN/ZLG)

## Checklist
- [x] Uses Conventional Commits in title (e.g., `feat(core): ...`)
- [x] Builds & tests pass locally (`dotnet build`, `dotnet test`)
- [ ] Updated docs / samples if behavior changed
- [x] Linked related issues

Fixes #43.